### PR TITLE
Fix CARTOSource instantiation for on-prem

### DIFF
--- a/src/lib/viz/sources/CARTOSource.ts
+++ b/src/lib/viz/sources/CARTOSource.ts
@@ -170,9 +170,15 @@ export class CARTOSource extends Source {
     const mapInstance: MapInstance = await mapsClient.instantiateMapFrom(this._mapConfig);
 
     const urlData = mapInstance.metadata.url.vector;
-    const urlTemplate = urlData.subdomains.map((subdomain: string) =>
-      urlData.urlTemplate.replace('{s}', subdomain)
-    );
+
+    let urlTemplate = [urlData.urlTemplate];
+
+    // if subdomains exist, then a collection of urls will be used for better performance
+    if (urlData.subdomains.length) {
+      urlTemplate = urlData.subdomains.map((subdomain: string) =>
+        urlData.urlTemplate.replace('{s}', subdomain)
+      );
+    }
 
     const { stats } = mapInstance.metadata.layers[0].meta;
 


### PR DESCRIPTION
 Ensure there is a urlTemplate for the MVTs, even if no subdomains are present. 

The fix is suggested by @Clebal, which detected the issue on the first place, and LGTM.