### PR TITLE
small styles fixes from review in cartoframes

### DIFF
--- a/examples/_debug/styles/color-continuous-style.html
+++ b/examples/_debug/styles/color-continuous-style.html
@@ -52,7 +52,25 @@
         tempLayer.addTo(deckMap);
       }
 
-      initialize();
+      async function initializePolygons() {
+        carto.setDefaultCredentials({ username: 'josemacarto' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -122.45292663574217,
+            latitude: 37.760944207425965,
+            zoom: 11
+          }
+        });
+
+        const style = carto.viz.colorContinuousStyle('businesses', {});
+        const tempLayer = new carto.viz.Layer('sf_businesses_neighborhoods', style);
+        tempLayer.addTo(deckMap);
+      }
+
+      // initialize();
+      initializePolygons();
     </script>
   </body>
 </html>

--- a/examples/_debug/styles/default style.html
+++ b/examples/_debug/styles/default style.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoJSON Layer with CARTO Tiles Example</title>
+
+    <!-- Custom CSS -->
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <section id="map"></section>
+
+    <!-- Map libraries-->
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.2.0-alpha.2/dist.min.js"></script>
+
+    <script src="/dist/umd/index.min.js"></script>
+
+    <script>
+      function initialize() {
+        carto.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -122.45292663574217,
+            latitude: 37.760944207425965,
+            zoom: 11
+          }
+        });
+
+        const layer = new carto.viz.Layer('global_power_plants');
+        layer.addTo(deckMap);
+      }
+
+      initialize();
+    </script>
+  </body>
+</html>

--- a/examples/_debug/styles/size-categories-style.html
+++ b/examples/_debug/styles/size-categories-style.html
@@ -36,7 +36,7 @@
 
     <script>
       function initializePoints() {
-        carto.setDefaultCredentials({ username: 'cartoframes' });
+        carto.setDefaultCredentials({ username: 'josemacarto' });
 
         const deckMap = carto.viz.createMap({
           basemap: 'voyager',
@@ -47,8 +47,8 @@
           }
         });
 
-        const style = carto.viz.sizeCategoriesStyle('category');
-        const layer = new carto.viz.Layer('sf_nbhd_crime', style);
+        const style = carto.viz.sizeCategoriesStyle('incident_day_of_week');
+        const layer = new carto.viz.Layer('sf_incidents', style);
         layer.addTo(deckMap);
       }
 
@@ -77,8 +77,8 @@
         layer.addTo(deckMap);
       }
 
-      // initializePoints();
-      initializeLines();
+      initializePoints();
+      // initializeLines();
     </script>
   </body>
 </html>

--- a/src/lib/viz/style/default-styles.ts
+++ b/src/lib/viz/style/default-styles.ts
@@ -2,12 +2,12 @@ const NULL_COLOR = '#ccc';
 const OTHERS_COLOR = '#777';
 const NULL_SIZE = 0;
 const STROKE_WIDTH = 0.5;
-const STROKE_COLOR = '#22222288';
+const STROKE_COLOR = '#22222244';
 
 export const defaultStyles: any = {
   Point: {
     color: '#EE4D5A',
-    size: 10,
+    size: 8,
     opacity: 1,
     strokeColor: STROKE_COLOR,
     strokeWidth: STROKE_WIDTH,

--- a/src/lib/viz/style/default-styles.ts
+++ b/src/lib/viz/style/default-styles.ts
@@ -9,7 +9,7 @@ export const defaultStyles: any = {
     color: '#EE4D5A',
     size: 8,
     opacity: 1,
-    strokeColor: STROKE_COLOR,
+    strokeColor: '#FFF',
     strokeWidth: STROKE_WIDTH,
     nullColor: NULL_COLOR,
     othersColor: OTHERS_COLOR,

--- a/src/lib/viz/style/default-styles.ts
+++ b/src/lib/viz/style/default-styles.ts
@@ -2,7 +2,7 @@ const NULL_COLOR = '#ccc';
 const OTHERS_COLOR = '#777';
 const NULL_SIZE = 0;
 const STROKE_WIDTH = 0.5;
-const STROKE_COLOR = '#22222244';
+const STROKE_COLOR = '#FFFFFF';
 
 export const defaultStyles: any = {
   Point: {

--- a/src/lib/viz/style/helpers/color-continuous-style.ts
+++ b/src/lib/viz/style/helpers/color-continuous-style.ts
@@ -24,7 +24,7 @@ function defaultOptions(
   options: Partial<ColorContinuousOptionsStyle>
 ): ColorContinuousOptionsStyle {
   return {
-    strokeWidth: 0,
+    strokeWidth: getDefaultStrokeWidth(geometryType, options),
     size: 6,
     palette: DEFAULT_PALETTE,
     nullColor: getStyleValue('nullColor', geometryType, options),
@@ -121,4 +121,15 @@ function validateParameters(options: ColorContinuousOptionsStyle) {
       stylingErrorTypes.PROPERTY_MISMATCH
     );
   }
+}
+
+function getDefaultStrokeWidth(
+  geometryType: GeometryType,
+  options: Partial<ColorContinuousOptionsStyle>
+) {
+  if (geometryType === 'Point') {
+    return options.strokeWidth || 0;
+  }
+
+  return getStyleValue('strokeWidth', geometryType, options);
 }

--- a/src/lib/viz/style/helpers/color-continuous-style.ts
+++ b/src/lib/viz/style/helpers/color-continuous-style.ts
@@ -25,6 +25,7 @@ function defaultOptions(
 ): ColorContinuousOptionsStyle {
   return {
     strokeWidth: 0,
+    size: 6,
     palette: DEFAULT_PALETTE,
     nullColor: getStyleValue('nullColor', geometryType, options),
     ...options

--- a/src/lib/viz/style/helpers/size-categories-style.ts
+++ b/src/lib/viz/style/helpers/size-categories-style.ts
@@ -23,6 +23,8 @@ function defaultOptions(
   return {
     top: 11,
     categories: [],
+    opacity: 0.7,
+    color: getDefaultColor(geometryType, options),
     sizeRange: getDefaultSizeRange(geometryType, options),
     nullSize: getStyleValue('nullSize', geometryType, options),
     ...options
@@ -166,4 +168,12 @@ export function getDefaultSizeRange(
   }
 
   return getStyleValue('sizeRange', geometryType, options);
+}
+
+function getDefaultColor(geometryType: GeometryType, options: Partial<SizeCategoriesOptionsStyle>) {
+  if (geometryType === 'Point') {
+    return options.color || '#F46D43';
+  }
+
+  return getStyleValue('color', geometryType, options);
 }


### PR DESCRIPTION
https://app.clubhouse.io/cartoteam/story/80830/styles-review-in-cartoframes-by-chemita

- [x] (1) review default styles (without helpers)
    It can not be solved completely since we are not supporting functions from cartoCSS. I have decreases a bit points size and stroke color opacity.

- [x] (2) color continuous: the distance between points is different
    The distance was right. I have decreased points size. Again, in CF we have a dynamic ramp we are not supporting here, so I have used a smaller but constant value

- [x] (3) size category with points: in VL color is orange! Also review opacity
    Done 

- [x] (4) size continuous with points: review stroke
    Same as before with ramp function.

- [x] (5) color continuous with polygons: stroke
    Added stroke just to polygons