### PR TITLE
[Fix] debounce attribute assignments

### DIFF
--- a/src/lib/dataviews/DataViewWrapper.ts
+++ b/src/lib/dataviews/DataViewWrapper.ts
@@ -47,14 +47,8 @@ export abstract class DataViewWrapper extends WithEvents {
   }
 
   public set column(column: string) {
-    debounce(
-      () => {
-        this.dataviewImpl.column = column;
-        this.emit('dataUpdate');
-      },
-      OPTION_CHANGED_DELAY,
-      this.setOptionScope
-    )(column);
+    this.dataviewImpl.column = column;
+    debounce(() => this.emit('dataUpdate'), OPTION_CHANGED_DELAY, this.setOptionScope)();
   }
 
   public get operation() {
@@ -62,14 +56,8 @@ export abstract class DataViewWrapper extends WithEvents {
   }
 
   public set operation(operation: AggregationType) {
-    debounce(
-      () => {
-        this.dataviewImpl.operation = operation;
-        this.emit('dataUpdate');
-      },
-      OPTION_CHANGED_DELAY,
-      this.setOptionScope
-    )(operation);
+    this.dataviewImpl.operation = operation;
+    debounce(() => this.emit('dataUpdate'), OPTION_CHANGED_DELAY, this.setOptionScope)();
   }
 
   private bindEvents() {

--- a/src/lib/dataviews/category/Category.ts
+++ b/src/lib/dataviews/category/Category.ts
@@ -39,15 +39,9 @@ export class Category extends DataViewWrapper {
     return (this.dataviewImpl as CategoryImpl<any>).operationColumn;
   }
   public set operationColumn(operationColumn: string) {
-    debounce(
-      () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (this.dataviewImpl as CategoryImpl<any>).operationColumn = operationColumn;
-        this.emit('dataUpdate');
-      },
-      OPTION_CHANGED_DELAY,
-      this.setOptionScope
-    )(operationColumn);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.dataviewImpl as CategoryImpl<any>).operationColumn = operationColumn;
+    debounce(() => this.emit('dataUpdate'), OPTION_CHANGED_DELAY, this.setOptionScope)();
   }
 
   public get limit() {
@@ -56,14 +50,8 @@ export class Category extends DataViewWrapper {
   }
 
   public set limit(limit: number | undefined) {
-    debounce(
-      () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (this.dataviewImpl as CategoryImpl<any>).limit = limit;
-        this.emit('dataUpdate');
-      },
-      OPTION_CHANGED_DELAY,
-      this.setOptionScope
-    )(limit);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.dataviewImpl as CategoryImpl<any>).limit = limit;
+    debounce(() => this.emit('dataUpdate'), OPTION_CHANGED_DELAY, this.setOptionScope)();
   }
 }


### PR DESCRIPTION
The attribute assignment statements are inside the debounce function which are being cancelled by others set methods. By this way if the user runs the following piece of code:

```typescript
dataview.column = column;
dataview.operation = operation;
dataview.limit = limit;
```

Only the option `limit` would be set.

This fixes that, by putting the attribute assignments outside the debounce method.