### PR TITLE
avoid setStyle + setSource errors 

### DIFF
--- a/src/lib/viz/__tests__/CARTOSource.spec.ts
+++ b/src/lib/viz/__tests__/CARTOSource.spec.ts
@@ -1,6 +1,6 @@
 import { Credentials, defaultCredentials, setDefaultCredentials } from '@/auth';
-
-import { CARTOSource } from '../sources/CARTOSource';
+import { Client } from '@/maps/Client';
+import { CARTOSource } from '@/viz/sources/CARTOSource';
 
 const TEST_CREDENTIALS = {
   username: 'test_username',
@@ -36,6 +36,24 @@ describe('CARTOSource', () => {
     it('should use default credentials if not provided', () => {
       const source = new CARTOSource(DEFAULT_DATASET);
       expect(source.credentials).toBe(defaultCredentials);
+    });
+  });
+
+  describe('Instantiation fails', () => {
+    beforeEach(() => {
+      setDefaultCredentials({ ...TEST_CREDENTIALS });
+
+      Client.prototype.instantiateMapFrom = jest.fn().mockImplementation(() => {
+        throw new Error('Error fake');
+      });
+    });
+
+    it('should fail with error in instantiation', async () => {
+      const source = new CARTOSource(DEFAULT_DATASET);
+
+      expect(async () => {
+        await source.init({ sample: new Set(), aggregation: new Set() });
+      }).rejects.toEqual(new Error('Error fake'));
     });
   });
 });

--- a/src/lib/viz/__tests__/GeoJsonSource.spec.ts
+++ b/src/lib/viz/__tests__/GeoJsonSource.spec.ts
@@ -217,4 +217,65 @@ describe('SourceMetadata', () => {
       ]
     });
   });
+
+  it('should fail if fields does not exist in geoJSON', async () => {
+    const fields = {
+      sample: new Set(['number', 'cat']),
+      aggregation: new Set(['number'])
+    };
+
+    const emptyGeojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: []
+    };
+
+    const source = new GeoJsonSource(emptyGeojson);
+
+    expect(async () => {
+      await source.init(fields);
+    }).rejects.toEqual(new Error("Field/s 'number, cat' do/es not exist in geoJSON properties"));
+  });
+
+  it('should fail if a field does not exist in geoJSON', async () => {
+    const fields = {
+      sample: new Set(['number', 'cat']),
+      aggregation: new Set(['number'])
+    };
+
+    const geojsonWithoutNumberField: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          id: 1,
+          geometry,
+          properties: {
+            cat: 'cat1'
+          }
+        },
+        {
+          type: 'Feature',
+          id: 1,
+          geometry,
+          properties: {
+            cat: 'cat1'
+          }
+        },
+        {
+          type: 'Feature',
+          id: 1,
+          geometry,
+          properties: {
+            cat: 'cat2'
+          }
+        }
+      ]
+    };
+
+    const source = new GeoJsonSource(geojsonWithoutNumberField);
+
+    expect(async () => {
+      await source.init(fields);
+    }).rejects.toEqual(new Error("Field/s 'number' do/es not exist in geoJSON properties"));
+  });
 });

--- a/src/lib/viz/__tests__/GeoJsonSource.spec.ts
+++ b/src/lib/viz/__tests__/GeoJsonSource.spec.ts
@@ -1,5 +1,6 @@
 import { Feature, FeatureCollection, Geometry, GeometryCollection } from 'geojson';
 import { GeoJsonSource, getGeomType, getFeatures, DEFAULT_GEOM } from '../sources/GeoJsonSource';
+import { SourceError } from '../errors/source-error';
 
 const GEOJSON_GEOM_TYPE = 'LineString';
 const GEOM_TYPE = 'Line';
@@ -218,7 +219,7 @@ describe('SourceMetadata', () => {
     });
   });
 
-  it('should fail if sample fields does not exist in geoJSON', async () => {
+  it('should fail if fields does not exist in geoJSON', async () => {
     const fields = {
       sample: new Set(['number', 'cat']),
       aggregation: new Set(['number'])
@@ -233,10 +234,12 @@ describe('SourceMetadata', () => {
 
     expect(async () => {
       await source.init(fields);
-    }).rejects.toEqual(new Error("Field/s 'number, cat' do/es not exist in geoJSON properties"));
+    }).rejects.toEqual(
+      new SourceError("Field/s 'number, cat' do/es not exist in geoJSON properties")
+    );
   });
 
-  it('should fail if a sample field does not exist in geoJSON', async () => {
+  it('should fail if a field does not exist in geoJSON', async () => {
     const fields = {
       sample: new Set(['number', 'cat']),
       aggregation: new Set(['number'])
@@ -276,6 +279,6 @@ describe('SourceMetadata', () => {
 
     expect(async () => {
       await source.init(fields);
-    }).rejects.toEqual(new Error("Field/s 'number' do/es not exist in geoJSON properties"));
+    }).rejects.toEqual(new SourceError("Field/s 'number' do/es not exist in geoJSON properties"));
   });
 });

--- a/src/lib/viz/__tests__/GeoJsonSource.spec.ts
+++ b/src/lib/viz/__tests__/GeoJsonSource.spec.ts
@@ -218,7 +218,7 @@ describe('SourceMetadata', () => {
     });
   });
 
-  it('should fail if fields does not exist in geoJSON', async () => {
+  it('should fail if sample fields does not exist in geoJSON', async () => {
     const fields = {
       sample: new Set(['number', 'cat']),
       aggregation: new Set(['number'])
@@ -236,7 +236,7 @@ describe('SourceMetadata', () => {
     }).rejects.toEqual(new Error("Field/s 'number, cat' do/es not exist in geoJSON properties"));
   });
 
-  it('should fail if a field does not exist in geoJSON', async () => {
+  it('should fail if a sample field does not exist in geoJSON', async () => {
     const fields = {
       sample: new Set(['number', 'cat']),
       aggregation: new Set(['number'])

--- a/src/lib/viz/sources/CARTOSource.ts
+++ b/src/lib/viz/sources/CARTOSource.ts
@@ -122,6 +122,33 @@ export class CARTOSource extends Source {
     return this._metadata;
   }
 
+  /**
+   * Instantiate the map, getting proper stats for input fields
+   * @param fields
+   */
+  public async init(fields: StatFields): Promise<boolean> {
+    if (!shouldInitialize(this.isInitialized, fields, this._fields)) {
+      return true;
+    }
+
+    if (this.isInitialized) {
+      console.warn('CARTOSource reinitialized');
+    }
+
+    this._saveFields(fields);
+    this._initConfigForStats();
+
+    const mapsClient = new Client(this._credentials);
+    const mapInstance: MapInstance = await mapsClient.instantiateMapFrom(this._mapConfig);
+
+    const urlTemplate = getUrlsFrom(mapInstance);
+    this._props = { type: 'TileLayer', data: urlTemplate }; // TODO refactor / include in metadata ?
+    this._metadata = extractMetadataFrom(mapInstance, fields);
+
+    this.isInitialized = true;
+    return this.isInitialized;
+  }
+
   private _initConfigForStats() {
     if (this._mapConfig.metadata === undefined) {
       throw new SourceError('Map Config has not metadata field');
@@ -152,33 +179,6 @@ export class CARTOSource extends Source {
       resolution: 1,
       threshold: 1
     };
-  }
-
-  /**
-   * Instantiate the map, getting proper stats for input fields
-   * @param fields
-   */
-  public async init(fields: StatFields): Promise<boolean> {
-    if (!shouldInitialize(this.isInitialized, fields, this._fields)) {
-      return true;
-    }
-
-    if (this.isInitialized) {
-      console.warn('CARTOSource reinitialized');
-    }
-
-    this._saveFields(fields);
-    this._initConfigForStats();
-
-    const mapsClient = new Client(this._credentials);
-    const mapInstance: MapInstance = await mapsClient.instantiateMapFrom(this._mapConfig);
-
-    const urlTemplate = getUrlsFrom(mapInstance);
-    this._props = { type: 'TileLayer', data: urlTemplate }; // TODO refactor / include in metadata ?
-    this._metadata = extractMetadataFrom(mapInstance, fields);
-
-    this.isInitialized = true;
-    return this.isInitialized;
   }
 
   private _saveFields(fields: StatFields) {

--- a/src/lib/viz/sources/GeoJsonSource.ts
+++ b/src/lib/viz/sources/GeoJsonSource.ts
@@ -98,6 +98,8 @@ export class GeoJsonSource extends Source {
       stats = this._calculateStats();
     }
 
+    this._validateFieldsInStats(stats);
+
     return stats;
   }
 
@@ -212,6 +214,23 @@ export class GeoJsonSource extends Source {
     }
 
     return categoryStats;
+  }
+
+  private _validateFieldsInStats(stats: (NumericFieldStats | CategoryFieldStats)[]) {
+    if (this._fields.sample.size) {
+      const requiredFields = [...this._fields.sample];
+      const existingStatsFields = stats
+        .filter(s => requiredFields.includes(s.name))
+        .map(s => s.name);
+
+      // some required fields do not have data in the geoJSON
+      if (existingStatsFields.length !== requiredFields.length) {
+        const noDataFields = requiredFields.filter(f => !existingStatsFields.includes(f));
+        throw new Error(
+          `Field/s '${noDataFields.join(', ')}' do/es not exist in geoJSON properties`
+        );
+      }
+    }
   }
 }
 


### PR DESCRIPTION
https://app.clubhouse.io/cartoteam/story/86687/avoid-styles-setsource-errors

- [x] validate fields used by styles exist in sources and throws a proper error about fields
- [x] validate fields used by popups exist in sources and throws a proper error about fields

Finally, second task of the issue is not covered in this PR. Please, read the issue comments for more info.