### PR TITLE
[Refactor API] r(e): carto.style

### DIFF
--- a/examples/_debug/basic/set-style-with-helper.html
+++ b/examples/_debug/basic/set-style-with-helper.html
@@ -55,7 +55,7 @@
           }
         });
 
-        const layerStyle = carto.viz.colorCategoriesStyle('room_type', {
+        const layerStyle = carto.viz.style.colorCategories('room_type', {
           categories: ['Entire home/apt', 'Private room', 'Shared room'],
 
           // palette accepts an array of HEX color strings,
@@ -68,7 +68,7 @@
       }
 
       function updateStyle() {
-        const newStyle = carto.viz.colorCategoriesStyle('room_type', {
+        const newStyle = carto.viz.style.colorCategories('room_type', {
           categories: ['Entire home/apt', 'Private room', 'Shared room'],
           palette: 'prism' // https://carto.com/carto-colors/
         });

--- a/examples/_debug/data-observatory/do-advanced.html
+++ b/examples/_debug/data-observatory/do-advanced.html
@@ -142,7 +142,7 @@
           layer.remove();
         }
 
-        const styles = carto.viz.colorBinsStyle(g.variable, {
+        const styles = carto.viz.style.colorBins(g.variable, {
           // breaks: [0, 2*(10**6), 5*(10**6), 8*(10**6), 100*(10**6)],
           // Methods allowed are quantiles, equal and stdev
           method: 'equal',

--- a/examples/_debug/data-observatory/do-source.html
+++ b/examples/_debug/data-observatory/do-source.html
@@ -56,7 +56,7 @@
 
         const DOVariable = 'total_pop_624c2d45';
 
-        const styles = carto.viz.colorBinsStyle(DOVariable, {
+        const styles = carto.viz.style.colorBins(DOVariable, {
           // breaks: [0, 2*(10**6), 5*(10**6), 8*(10**6), 100*(10**6)],
           // Methods allowed are quantiles, equal and stdev
           method: 'equal',

--- a/examples/_debug/dataview/category-aggregated-count-geojson.html
+++ b/examples/_debug/dataview/category-aggregated-count-geojson.html
@@ -84,7 +84,7 @@
 
         const deckMap = carto.viz.createMap();
 
-        const basicStyle = carto.viz.basicStyle({
+        const basicStyle = carto.viz.style.basic({
           color: '#0000FF',
           size: 14,
           strokeColor: '#0000FF44',

--- a/examples/_debug/interactivity/add-popups-onhover.html
+++ b/examples/_debug/interactivity/add-popups-onhover.html
@@ -78,7 +78,7 @@
           }
         });
 
-        const sizeBinStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const sizeBinStyle = new carto.viz.style.sizeBins('pop_2015', {
           sizeRange: [1, 50]
         });
         const populationLayer = new carto.viz.Layer('world_population_2015', sizeBinStyle);

--- a/examples/_debug/interactivity/enable-disable-onhover-onclick.html
+++ b/examples/_debug/interactivity/enable-disable-onhover-onclick.html
@@ -100,7 +100,7 @@
           }
         });
 
-        const sizeBinStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const sizeBinStyle = new carto.viz.style.sizeBins('pop_2015', {
           sizeRange: [1, 50]
         });
         const populationLayer = new carto.viz.Layer('world_population_2015', sizeBinStyle);

--- a/examples/_debug/interactivity/feature-click-and-stylehelper.html
+++ b/examples/_debug/interactivity/feature-click-and-stylehelper.html
@@ -74,7 +74,7 @@
           }
         });
 
-        const style = carto.viz.colorCategoriesStyle('landuse_type');
+        const style = carto.viz.style.colorCategories('landuse_type');
         const countriesLayer = new carto.viz.Layer('wburg_parcels', style);
         countriesLayer.on('click', ([features, coordinates]) => {
           let content = '';

--- a/examples/_debug/interactivity/size-bins-style-and-popup.html
+++ b/examples/_debug/interactivity/size-bins-style-and-popup.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const sizeBinStyle = carto.viz.sizeBinsStyle('availability_365');
+        const sizeBinStyle = carto.viz.style.sizeBins('availability_365');
 
         const populationLayer = new carto.viz.Layer('listings_madrid', sizeBinStyle);
 

--- a/examples/_debug/source/geojson/color-bins-style.html
+++ b/examples/_debug/source/geojson/color-bins-style.html
@@ -50,7 +50,7 @@
           }
         });
 
-        const style = carto.viz.colorBinsStyle('gdp_md_est');
+        const style = carto.viz.style.colorBins('gdp_md_est');
         const layer = new carto.viz.Layer(data, style);
         layer.addTo(deckMap);
       }

--- a/examples/_debug/source/geojson/color-categories-style.html
+++ b/examples/_debug/source/geojson/color-categories-style.html
@@ -50,7 +50,7 @@
           }
         });
 
-        const style = carto.viz.colorCategoriesStyle('name');
+        const style = carto.viz.style.colorCategories('name');
         const layer = new carto.viz.Layer(data, style);
         layer.addTo(deckMap);
       }

--- a/examples/_debug/source/geojson/color-continuous-style.html
+++ b/examples/_debug/source/geojson/color-continuous-style.html
@@ -50,7 +50,7 @@
           }
         });
 
-        const style = carto.viz.colorContinuousStyle('long_min');
+        const style = carto.viz.style.colorContinuous('long_min');
         const layer = new carto.viz.Layer(data, style);
         layer.addTo(deckMap);
       }

--- a/examples/_debug/source/geojson/size-bins-style.html
+++ b/examples/_debug/source/geojson/size-bins-style.html
@@ -50,7 +50,7 @@
           }
         });
 
-        const style = carto.viz.sizeBinsStyle('long_min');
+        const style = carto.viz.style.sizeBins('long_min');
         const layer = new carto.viz.Layer(data, style);
         layer.addTo(deckMap);
       }

--- a/examples/_debug/source/geojson/size-categories-style.html
+++ b/examples/_debug/source/geojson/size-categories-style.html
@@ -50,7 +50,7 @@
           }
         });
 
-        const style = carto.viz.sizeCategoriesStyle('harbortype');
+        const style = carto.viz.style.sizeCategories('harbortype');
         const layer = new carto.viz.Layer(data, style);
         layer.addTo(deckMap);
       }

--- a/examples/_debug/source/geojson/size-continuous-style.html
+++ b/examples/_debug/source/geojson/size-continuous-style.html
@@ -50,7 +50,7 @@
           }
         });
 
-        const style = carto.viz.sizeContinuousStyle('harbortype');
+        const style = carto.viz.style.sizeContinuous('harbortype');
         const layer = new carto.viz.Layer(data, style);
         layer.addTo(deckMap);
       }

--- a/examples/_debug/source/reinstantiation.html
+++ b/examples/_debug/source/reinstantiation.html
@@ -84,7 +84,7 @@
           }
         });
 
-        const sizeBinStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const sizeBinStyle = new carto.viz.style.sizeBins('pop_2015', {
           color: '#0000FF'
         });
 

--- a/examples/_debug/styles/basic-style.html
+++ b/examples/_debug/styles/basic-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const basicStyle = carto.viz.basicStyle({
+        const basicStyle = carto.viz.style.basic({
           // color: '#831123',
           // opacity: 0.7,
           // strokeColor: '#fff',
@@ -69,7 +69,7 @@
           }
         });
 
-        const basicStyle = carto.viz.basicStyle({
+        const basicStyle = carto.viz.style.basic({
           // color: '#0000FF',
           // size: 5
         });
@@ -89,7 +89,7 @@
           }
         });
 
-        const basicStyle = carto.viz.basicStyle({
+        const basicStyle = carto.viz.style.basic({
           color: '#0000FF',
           size: 20,
           strokeColor: '#0000FF44',

--- a/examples/_debug/styles/color-bins-style.html
+++ b/examples/_debug/styles/color-bins-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const style = carto.viz.colorBinsStyle('availability_365', {
+        const style = carto.viz.style.colorBins('availability_365', {
           bins: 5,
           method: 'quantiles'
           // breaks: [],
@@ -69,7 +69,7 @@
           }
         });
 
-        const style = carto.viz.colorBinsStyle('length_km');
+        const style = carto.viz.style.colorBins('length_km');
         const layer = new carto.viz.Layer('roads', style);
         layer.addTo(deckMap);
       }
@@ -86,7 +86,7 @@
           }
         });
 
-        const style = carto.viz.colorBinsStyle('pop_sq_km', {
+        const style = carto.viz.style.colorBins('pop_sq_km', {
           // color: '#0000FF',
           // size: 5
         });

--- a/examples/_debug/styles/color-categories-style.html
+++ b/examples/_debug/styles/color-categories-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const style = carto.viz.colorCategoriesStyle('category');
+        const style = carto.viz.style.colorCategories('category');
         const layer = new carto.viz.Layer('sf_nbhd_crime', style);
         layer.addTo(deckMap);
       }
@@ -64,7 +64,7 @@
           }
         });
 
-        const style = carto.viz.colorCategoriesStyle('type');
+        const style = carto.viz.style.colorCategories('type');
         const layer = new carto.viz.Layer('roads', style);
         layer.addTo(deckMap);
       }
@@ -81,7 +81,7 @@
           }
         });
 
-        const style = carto.viz.colorCategoriesStyle('landuse_type');
+        const style = carto.viz.style.colorCategories('landuse_type');
         const layer = new carto.viz.Layer('wburg_parcels', style);
         layer.addTo(deckMap);
       }
@@ -98,7 +98,7 @@
           }
         });
 
-        const style = carto.viz.colorCategoriesStyle('region', {
+        const style = carto.viz.style.colorCategories('region', {
           // color: '#0000FF',
           // size: 5
         });

--- a/examples/_debug/styles/color-continuous-style.html
+++ b/examples/_debug/styles/color-continuous-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const style = carto.viz.colorContinuousStyle('value', {});
+        const style = carto.viz.style.colorContinuous('value', {});
         const tempLayer = new carto.viz.Layer('temps', style);
         tempLayer.addTo(deckMap);
       }
@@ -64,7 +64,7 @@
           }
         });
 
-        const style = carto.viz.colorContinuousStyle('businesses', {});
+        const style = carto.viz.style.colorContinuous('businesses', {});
         const tempLayer = new carto.viz.Layer('sf_businesses_neighborhoods', style);
         tempLayer.addTo(deckMap);
       }

--- a/examples/_debug/styles/size-bins-style.html
+++ b/examples/_debug/styles/size-bins-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const style = carto.viz.sizeBinsStyle('sale_price', {
+        const style = carto.viz.style.sizeBins('sale_price', {
           // bins: 3
         });
         const layer = new carto.viz.Layer('clev_sales', style);
@@ -66,7 +66,7 @@
           }
         });
 
-        const style = carto.viz.sizeBinsStyle('length_km', {
+        const style = carto.viz.style.sizeBins('length_km', {
           bins: 3,
           sizeRange: [1, 5]
         });

--- a/examples/_debug/styles/size-categories-style.html
+++ b/examples/_debug/styles/size-categories-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const style = carto.viz.sizeCategoriesStyle('incident_day_of_week');
+        const style = carto.viz.style.sizeCategories('incident_day_of_week');
         const layer = new carto.viz.Layer('sf_incidents', style);
         layer.addTo(deckMap);
       }
@@ -64,7 +64,7 @@
           }
         });
 
-        const style = carto.viz.sizeCategoriesStyle('type');
+        const style = carto.viz.style.sizeCategories('type');
 
         const source = new carto.viz.source.Dataset('roads', {
           mapOptions: {

--- a/examples/_debug/styles/size-continuous-style.html
+++ b/examples/_debug/styles/size-continuous-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const style = carto.viz.sizeContinuousStyle('total_pop', {
+        const style = carto.viz.style.sizeContinuous('total_pop', {
           rangeMin: 100000,
           rangeMax: 5000000,
           sizeRange: [5, 50],

--- a/examples/_old/styles/barcelona.html
+++ b/examples/_old/styles/barcelona.html
@@ -51,12 +51,12 @@
           }
         });
 
-        const categoryStyleWithCARTOColors = carto.viz.colorCategoriesStyle('category', {
+        const categoryStyleWithCARTOColors = carto.viz.style.colorCategories('category', {
           categories: ['Moda y calzado', 'Salud', 'Alimentación', 'Bares y restaurantes'],
           palette: 'vivid'
         });
 
-        const categoryStyle = carto.viz.colorCategoriesStyle('category', {
+        const categoryStyle = carto.viz.style.colorCategories('category', {
           categories: ['Moda y calzado', 'Salud', 'Alimentación', 'Bares y restaurantes'],
 
           // colors accepts an array of HEX color strings,

--- a/examples/_old/styles/higher-education.html
+++ b/examples/_old/styles/higher-education.html
@@ -51,7 +51,7 @@
           }
         });
 
-        const percentageStyleWithCARTOColors = carto.viz.colorBinsStyle('pct_higher_ed', {
+        const percentageStyleWithCARTOColors = carto.viz.style.colorBins('pct_higher_ed', {
           // colors accepts an array of HEX color strings,
           // or a string pointing to a CARTOColors palette
           palette: 'pinkyl',

--- a/examples/basic/set-style.html
+++ b/examples/basic/set-style.html
@@ -69,7 +69,7 @@
       initialize();
 
       function updateStyle() {
-        const newStyle = carto.viz.colorCategoriesStyle('continent');
+        const newStyle = carto.viz.style.colorCategories('continent');
         countries.setStyle(newStyle);
       }
     </script>

--- a/examples/interactivity/add-popups-onclick.html
+++ b/examples/interactivity/add-popups-onclick.html
@@ -81,7 +81,7 @@
           }
         });
 
-        const sizeBinStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const sizeBinStyle = new carto.viz.style.sizeBins('pop_2015', {
           sizeRange: [1, 50]
         });
         const populationLayer = new carto.viz.Layer('world_population_2015', sizeBinStyle);

--- a/examples/interactivity/add-popups-onhover.html
+++ b/examples/interactivity/add-popups-onhover.html
@@ -76,7 +76,7 @@
           }
         });
 
-        const sizeBinStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const sizeBinStyle = new carto.viz.style.sizeBins('pop_2015', {
           sizeRange: [1, 50]
         });
         const populationLayer = new carto.viz.Layer('world_population_2015', sizeBinStyle);

--- a/examples/interactivity/disable-onhover.html
+++ b/examples/interactivity/disable-onhover.html
@@ -93,7 +93,7 @@
           }
         });
 
-        const sizeBinStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const sizeBinStyle = new carto.viz.style.sizeBins('pop_2015', {
           sizeRange: [1, 50]
         });
         const populationLayer = new carto.viz.Layer('world_population_2015', sizeBinStyle);

--- a/examples/interactivity/interactive-based-styling-default.html
+++ b/examples/interactivity/interactive-based-styling-default.html
@@ -115,14 +115,14 @@
           }
         });
 
-        const pointsStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const pointsStyle = new carto.viz.style.sizeBins('pop_2015', {
           sizeRange: [1, 50]
         });
         points = new carto.viz.Layer('world_population_2015', pointsStyle, {
           hoverStyle: 'default',
           clickStyle: 'default'
         });
-        const linesStyle = new carto.viz.sizeBinsStyle('classcode', {
+        const linesStyle = new carto.viz.style.sizeBins('classcode', {
           sizeRange: [2, 7]
         });
         lines = new carto.viz.Layer('sf_stclines', linesStyle, {

--- a/examples/interactivity/interactive-based-styling.html
+++ b/examples/interactivity/interactive-based-styling.html
@@ -77,7 +77,7 @@
           }
         });
 
-        const sizeBinStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const sizeBinStyle = new carto.viz.style.sizeBins('pop_2015', {
           sizeRange: [1, 50]
         });
         const populationLayer = new carto.viz.Layer('world_population_2015', sizeBinStyle, {

--- a/examples/interactivity/popups-format.html
+++ b/examples/interactivity/popups-format.html
@@ -82,7 +82,7 @@
           }
         });
 
-        const sizeBinStyle = new carto.viz.sizeBinsStyle('pop_2015', {
+        const sizeBinStyle = new carto.viz.style.sizeBins('pop_2015', {
           sizeRange: [1, 50]
         });
         const populationLayer = new carto.viz.Layer('world_population_2015', sizeBinStyle);

--- a/examples/sources/DO.html
+++ b/examples/sources/DO.html
@@ -76,7 +76,7 @@
 
         const DOVariable = 'total_pop_624c2d45';
 
-        const styles = carto.viz.colorBinsStyle(DOVariable, {
+        const styles = carto.viz.style.colorBins(DOVariable, {
           // breaks: [0, 2*(10**6), 5*(10**6), 8*(10**6), 100*(10**6)],
           // Methods allowed are quantiles, equal and stdev
           method: 'equal',

--- a/examples/sources/geojson.html
+++ b/examples/sources/geojson.html
@@ -61,7 +61,7 @@
 
         const deckMap = carto.viz.createMap();
 
-        const basicStyle = carto.viz.basicStyle({
+        const basicStyle = carto.viz.style.basic({
           color: '#0000FF',
           size: 14,
           strokeColor: '#0000FF44',

--- a/examples/style-helpers/basic-style.html
+++ b/examples/style-helpers/basic-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const basicStyle = carto.viz.basicStyle({
+        const basicStyle = carto.viz.style.basic({
           // Color: hex, rgb or named color value.
           // Defaults is '#EE4D5A' points, '#4CC8A3'lines and '#826DBA' polygons
           color: '#831123',

--- a/examples/style-helpers/color-bins-style.html
+++ b/examples/style-helpers/color-bins-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const availabilityStyle = carto.viz.colorBinsStyle('availability_365');
+        const availabilityStyle = carto.viz.style.colorBins('availability_365');
         const airbnbLayer = new carto.viz.Layer('listings_madrid', availabilityStyle);
         airbnbLayer.addTo(deckMap);
       }

--- a/examples/style-helpers/color-categories-style.html
+++ b/examples/style-helpers/color-categories-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const roomTypeStyle = carto.viz.colorCategoriesStyle('room_type');
+        const roomTypeStyle = carto.viz.style.colorCategories('room_type');
         const airbnbLayer = new carto.viz.Layer('listings_madrid', roomTypeStyle);
         airbnbLayer.addTo(deckMap);
       }

--- a/examples/style-helpers/color-continuous-style.html
+++ b/examples/style-helpers/color-continuous-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const style = carto.viz.colorContinuousStyle('value', {
+        const style = carto.viz.style.colorContinuous('value', {
           rangeMin: 80,
           rangeMax: 100
         });

--- a/examples/style-helpers/size-bins-style.html
+++ b/examples/style-helpers/size-bins-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const availabilityStyle = carto.viz.sizeBinsStyle('availability_365');
+        const availabilityStyle = carto.viz.style.sizeBins('availability_365');
         const airbnbLayer = new carto.viz.Layer('listings_madrid', availabilityStyle);
         airbnbLayer.addTo(deckMap);
       }

--- a/examples/style-helpers/size-categories-style.html
+++ b/examples/style-helpers/size-categories-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const roomTypeStyle = carto.viz.sizeCategoriesStyle('type');
+        const roomTypeStyle = carto.viz.style.sizeCategories('type');
         const airbnbLayer = new carto.viz.Layer('roads', roomTypeStyle);
         airbnbLayer.addTo(deckMap);
       }

--- a/examples/style-helpers/size-continuous-style.html
+++ b/examples/style-helpers/size-continuous-style.html
@@ -47,7 +47,7 @@
           }
         });
 
-        const style = carto.viz.sizeContinuousStyle('total_pop');
+        const style = carto.viz.style.sizeContinuous('total_pop');
         const tempLayer = new carto.viz.Layer('ca_measures', style);
         tempLayer.addTo(deckMap);
       }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -60,15 +60,6 @@ const source = {
 
 const basemaps = { createMap, createGoogleMap };
 const basics = { Layer, Popup };
-const styles = {
-  basicStyle,
-  colorBinsStyle,
-  colorCategoriesStyle,
-  colorContinuousStyle,
-  sizeBinsStyle,
-  sizeCategoriesStyle,
-  sizeContinuousStyle
-};
 
 // dataview
 const dataview = {
@@ -84,11 +75,22 @@ const widget = {
   Histogram: HistogramWidget
 };
 
+// style
+const style = {
+  basic: basicStyle,
+  colorBins: colorBinsStyle,
+  colorCategories: colorCategoriesStyle,
+  colorContinuous: colorContinuousStyle,
+  sizeBins: sizeBinsStyle,
+  sizeCategories: sizeCategoriesStyle,
+  sizeContinuous: sizeContinuousStyle
+};
+
 export const viz = {
   source,
   dataview,
   widget,
+  style,
   ...basemaps,
-  ...styles,
   ...basics
 };


### PR DESCRIPTION
- Removing `Style` sufix from helpers.
- Exposing `style` namespace within `viz`.