### PR TITLE
improve error message using an invalid column for size category helper

### DIFF
--- a/src/lib/viz/style/helpers/size-categories-style.ts
+++ b/src/lib/viz/style/helpers/size-categories-style.ts
@@ -56,7 +56,7 @@ export function sizeCategoriesStyle(
       const stats = meta.stats.find(c => c.name === featureProperty) as CategoryFieldStats;
 
       if (!stats.categories || !stats.categories.length) {
-        throw new CartoStylingError('The featureProperty has not categories');
+        throw new CartoStylingError(`Current dataset has not categories for '${featureProperty}'`);
       }
 
       categories = stats.categories.map((c: Category) => c.category);


### PR DESCRIPTION
When using an invalid column for size category helper, the error was:

`The featureProperty has not categories`

I am changing it to:

`Current dataset has not categories for 'your_column_used'`