### PR TITLE
improve data events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Add `beforeLayerId` and `afterLayerId` options to `carto.viz.Layer.addTo` method, to customize layer position
 - Widget synchronization when using remote dataviews ([#76](https://github.com/CartoDB/web-sdk/pull/76/))
 - `icon` style helper 
-- Adding new data state in Layer ([#84](https://github.com/CartoDB/web-sdk/pull/84)) for sending data events when data is ready or updated
+- New data events in Layer: `layerDataReady` and `layerDataChanged` ([#84](https://github.com/CartoDB/web-sdk/pull/84))
 
 ### Changed
 - Remove d3.format option from `carto.viz.Popup`
@@ -19,5 +19,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [1.0.0-alpha.0] 2020-07-06
 - First release
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Add `beforeLayerId` and `afterLayerId` options to `carto.viz.Layer.addTo` method, to customize layer position
 - Widget synchronization when using remote dataviews ([#76](https://github.com/CartoDB/web-sdk/pull/76/))
 - `icon` style helper 
+- Adding new data state in Layer ([#84](https://github.com/CartoDB/web-sdk/pull/84)) for sending data events when data is ready or updated
 
 ### Changed
 - Remove d3.format option from `carto.viz.Popup`

--- a/examples/_debug/source/layer-dataview-validation.html
+++ b/examples/_debug/source/layer-dataview-validation.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Category widget</title>
+
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
+    />
+
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://libs.cartocdn.com/airship-style/v2.4/airship.min.css"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+
+      #panel {
+        width: 300px;
+      }
+      #panel .as-box {
+        width: 250px;
+      }
+    </style>
+  </head>
+
+  <body class="as-app-body as-app">
+    <div class="as-content">
+      <main class="as-main">
+        <div class="as-map-area">
+          <!-- map -->
+          <div id="map"></div>
+
+          <!-- panel -->
+          <div id="panel" class="as-panel as-panel--top as-panel--right as-bg--ui-01">
+            <div class="as-panel__element as-p--16 as-body">
+              <div class="as-container as-container--scrollable">
+                <section class="as-box">
+                  <h1 class="as-title">Category widget</h1>
+                  <h4 class="as-subheader as-mb--12">
+                    Create a widget, aggregating values per category, for those features currently
+                    visible. It includes a filtering feature out of the box
+                  </h4>
+                </section>
+                <section class="as-box">
+                  <as-category-widget
+                    heading="Countries"
+                    description="Number of countries by continent"
+                  >
+                  </as-category-widget>
+                </section>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
+    <script src="https://libs.cartocdn.com/airship-components/v2.4/airship.js"></script>
+    <script src="/dist/umd/index.min.js"></script>
+
+    <script>
+      const widgetElement = document.querySelector('as-category-widget');
+
+      async function initialize() {
+        carto.auth.setDefaultCredentials({ username: 'public' });
+        const deckMap = carto.viz.createMap();
+
+        const geojsonData = await fetch('https://public.carto.com/api/v2/sql?api_key=default_public&q=select* from world_ports&format=geojson').then(response => response.json());
+        const layer = new carto.viz.Layer(geojsonData);
+        // const layer = new carto.viz.Layer('world_ports');
+
+        await layer.addTo(deckMap);
+
+        // A data-view to count
+        const dataview = new carto.viz.dataview.Category(layer, 'harbortype', {
+          operation: 'count',
+          spatialFilter: 'viewport'
+        });
+
+        new carto.viz.widget.Category('as-category-widget', dataview);
+      }
+
+      initialize();
+    </script>
+  </body>
+</html>

--- a/examples/_debug/source/points-geojson-viewport-features.html
+++ b/examples/_debug/source/points-geojson-viewport-features.html
@@ -63,7 +63,7 @@
         const countriesLayer = new carto.viz.Layer(data);
 
         // vieportLoad will be triggered after every viewport change (zoom, pan...)
-        countriesLayer.on('viewportLoad', async () => {
+        countriesLayer.on('layerDataChanged', async () => {
           const features = await countriesLayer.getViewportFeatures();
 
           // clear the panel

--- a/examples/_debug/source/polygons-geojson-viewport-features.html
+++ b/examples/_debug/source/polygons-geojson-viewport-features.html
@@ -62,7 +62,7 @@
         const countriesLayer = new carto.viz.Layer(data);
 
         // vieportLoad will be triggered after every viewport change (zoom, pan...)
-        countriesLayer.on('viewportLoad', async () => {
+        countriesLayer.on('layerDataChanged', async () => {
           const features = await countriesLayer.getViewportFeatures();
 
           // clear the panel

--- a/examples/dataview/viewport-features.html
+++ b/examples/dataview/viewport-features.html
@@ -61,7 +61,7 @@
         const countriesLayer = new carto.viz.Layer('ne_50m_admin_0_countries');
 
         // vieportLoad will be triggered after every viewport change (zoom, pan...)
-        countriesLayer.on('viewportLoad', async () => {
+        countriesLayer.on('layerDataChanged', async () => {
           const features = await countriesLayer.getViewportFeatures();
 
           // clear the panel

--- a/src/lib/viz/dataview/dataview.spec.ts
+++ b/src/lib/viz/dataview/dataview.spec.ts
@@ -1,4 +1,4 @@
-import { Layer } from '../layer/Layer';
+import { Layer, DATA_CHANGED_EVENT } from '../layer/Layer';
 import { DataViewLocal } from './mode/DataViewLocal';
 import { CartoDataViewError, dataViewErrorTypes } from './DataViewError';
 
@@ -36,7 +36,7 @@ describe('DataView', () => {
       const dataUpdateSpy = jest.fn();
       dataView.on('dataUpdate', dataUpdateSpy);
 
-      layer.emit('viewportLoad');
+      layer.emit(DATA_CHANGED_EVENT);
 
       expect(dataUpdateSpy).toHaveBeenCalled();
     });

--- a/src/lib/viz/dataview/mode/DataViewLocal.ts
+++ b/src/lib/viz/dataview/mode/DataViewLocal.ts
@@ -1,4 +1,5 @@
 import { Layer } from '@/viz';
+import { DATA_CHANGED_EVENT } from '@/viz/layer/Layer';
 import { AggregationType, aggregate } from '@/data/operations/aggregation/aggregation';
 import { groupValuesByColumn } from '@/data/operations/grouping';
 import { castToNumberOrUndefined } from '@/core/utils/number';
@@ -62,7 +63,7 @@ export class DataViewLocal extends DataViewMode {
   private bindEvents() {
     this.registerAvailableEvents(['dataUpdate', 'error']);
 
-    this.dataSource.on('viewportLoad', () => {
+    this.dataSource.on(DATA_CHANGED_EVENT, () => {
       this.onDataUpdate();
     });
 

--- a/src/lib/viz/dataview/mode/DataViewRemote.ts
+++ b/src/lib/viz/dataview/mode/DataViewRemote.ts
@@ -1,6 +1,7 @@
 import { MapsDataviews as DataviewsApi } from '@/maps/MapsDataviews';
 import { defaultCredentials } from '@/auth';
 import { Layer, Source, SQLSource, DatasetSource } from '@/viz';
+import { DATA_CHANGED_EVENT } from '@/viz/layer/Layer';
 import { Filter, SpatialFilters, ColumnFilters } from '@/viz/filters/types';
 import { FiltersCollection } from '@/viz/filters/FiltersCollection';
 import { RemoteFilterApplicator } from '@/viz/filters/RemoteFilterApplicator';
@@ -70,7 +71,7 @@ export class DataViewRemote extends DataViewMode {
       );
     }
 
-    this.dataSource.on('viewportLoad', () => {
+    this.dataSource.on(DATA_CHANGED_EVENT, () => {
       const deckInstance = (this.dataSource as Layer).getMapInstance();
       const viewport = deckInstance.getViewports(undefined)[0];
 

--- a/src/lib/viz/interactivity/viewport-features/ViewportFeaturesGenerator.ts
+++ b/src/lib/viz/interactivity/viewport-features/ViewportFeaturesGenerator.ts
@@ -60,7 +60,16 @@ export class ViewportFeaturesGenerator {
 
   private async getGeoJSONLayerFeatures(properties: string[] = []) {
     const features = this.getGeoJSONFeatures();
-    const viewport = this.getViewport();
+    let viewport: Viewport;
+
+    try {
+      viewport = this.getViewport();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('Viewport not ready');
+      return [];
+    }
+
     const currentFrustumPlanes = viewport.getFrustumPlanes();
 
     return features

--- a/src/lib/viz/interactivity/viewport-features/ViewportFeaturesGenerator.ts
+++ b/src/lib/viz/interactivity/viewport-features/ViewportFeaturesGenerator.ts
@@ -1,9 +1,8 @@
 import { Deck, Viewport, WebMercatorViewport } from '@deck.gl/core';
 import { MVTLayer } from '@deck.gl/geo-layers';
 import { Matrix4 } from '@math.gl/core';
-import { GeoJSON } from 'geojson';
+import { GeoJSON, Feature } from 'geojson';
 import { GeoJsonLayer, IconLayer } from '@deck.gl/layers';
-import { getFeatures } from '@/viz/source/GeoJSONSource';
 import { selectPropertiesFrom } from '../../utils/object';
 import { ViewportTile } from '../../declarations/deckgl';
 import { GeometryData, ViewportFrustumPlanes } from './geometry/types';
@@ -146,13 +145,12 @@ export class ViewportFeaturesGenerator {
     return this.deckLayer.state.tileset.selectedTiles;
   }
 
-  private getGeoJSONFeatures() {
+  private getGeoJSONFeatures(): Feature[] {
     if (!this.deckLayer || !this.deckLayer.props || !this.deckLayer.props.data) {
       return [];
     }
 
-    const geoJSON = (this.deckLayer.props.data as unknown) as GeoJSON;
-    return getFeatures(geoJSON);
+    return (this.deckLayer.props.data as unknown) as Feature[];
   }
 
   private getViewport() {

--- a/src/lib/viz/layer/Layer.ts
+++ b/src/lib/viz/layer/Layer.ts
@@ -516,6 +516,10 @@ export class Layer extends WithEvents implements StyledLayer {
     isRotating: boolean,
     viewState: ViewState
   ) {
+    if (!isPanning && !isZooming && !isRotating) {
+      return false;
+    }
+
     this.dataState.isPanning = isPanning;
     this.dataState.isZooming = isZooming;
     this.dataState.isRotating = isRotating;
@@ -526,6 +530,8 @@ export class Layer extends WithEvents implements StyledLayer {
       const viewport = new WebMercatorViewport(viewState);
       this._viewportFeaturesGenerator.setViewport(viewport);
     }
+
+    return true;
   }
 
   private sendDataEvent(referer: 'onViewportLoad' | 'onAfterRender') {
@@ -533,6 +539,7 @@ export class Layer extends WithEvents implements StyledLayer {
 
     if (this.dataState.isFirstTime && (isGeoJsonLayer || referer === 'onViewportLoad')) {
       this.dataState.isFirstTime = false;
+
       this.emit('viewportLoad'); // TODO: remove
       return this.emit(DATA_READY_EVENT);
     }
@@ -543,6 +550,10 @@ export class Layer extends WithEvents implements StyledLayer {
       this.dataState.isRotating ||
       referer === 'onViewportLoad'
     ) {
+      this.dataState.isPanning = false;
+      this.dataState.isZooming = false;
+      this.dataState.isRotating = false;
+
       this.emit('viewportLoad'); // TODO: remove
       return this.emit(DATA_CHANGED_EVENT);
     }

--- a/src/lib/viz/layer/Layer.ts
+++ b/src/lib/viz/layer/Layer.ts
@@ -84,7 +84,7 @@ export class Layer extends WithEvents implements StyledLayer {
     };
 
     this._interactivity = this._buildInteractivity(options);
-    this.dataState = buildDataState();
+    this.dataState = buildInitialDataState();
   }
 
   getMapInstance(): Deck {
@@ -105,6 +105,7 @@ export class Layer extends WithEvents implements StyledLayer {
    */
   public async setSource(source: string | Source) {
     this._source = buildSource(source);
+    this.dataState = buildInitialDataState();
 
     if (this._deckLayer) {
       await this.replaceDeckGLLayer();
@@ -639,7 +640,7 @@ interface LayerPosition {
   afterLayerId?: string;
 }
 
-function buildDataState() {
+function buildInitialDataState() {
   return {
     isFirstTime: true,
     isPanning: false,

--- a/src/lib/viz/layer/Layer.ts
+++ b/src/lib/viz/layer/Layer.ts
@@ -532,6 +532,7 @@ export class Layer extends WithEvents implements StyledLayer {
     ) {
       this.emit('viewportLoad'); // TODO: remove
       this.emit(DATA_READY_EVENT);
+      this.emit(DATA_CHANGED_EVENT);
     }
 
     if (this.dataState === DATA_STATES.UPDATING || referer === 'onViewportLoad') {

--- a/src/lib/viz/layer/Layer.ts
+++ b/src/lib/viz/layer/Layer.ts
@@ -22,8 +22,8 @@ import { FunctionFilterApplicator } from '../filters/FunctionFilterApplicator';
 import { ColumnFilters } from '../filters/types';
 import { basicStyle } from '../style/helpers/basic-style';
 
-const DATA_READY_EVENT = 'layerDataReady';
-const DATA_CHANGED_EVENT = 'layerDataChanged';
+export const DATA_READY_EVENT = 'layerDataReady';
+export const DATA_CHANGED_EVENT = 'layerDataChanged';
 
 enum DATA_STATES {
   STARTING,
@@ -71,7 +71,6 @@ export class Layer extends WithEvents implements StyledLayer {
     this.registerAvailableEvents([
       DATA_READY_EVENT,
       DATA_CHANGED_EVENT,
-      'viewportLoad',
       'filterChange',
       InteractivityEventType.CLICK.toString(),
       InteractivityEventType.HOVER.toString()
@@ -530,13 +529,11 @@ export class Layer extends WithEvents implements StyledLayer {
       this.dataState === DATA_STATES.STARTING &&
       (isGeoJsonLayer || referer === 'onViewportLoad')
     ) {
-      this.emit('viewportLoad'); // TODO: remove
       this.emit(DATA_READY_EVENT);
       this.emit(DATA_CHANGED_EVENT);
     }
 
     if (this.dataState === DATA_STATES.UPDATING || referer === 'onViewportLoad') {
-      this.emit('viewportLoad'); // TODO: remove
       this.emit(DATA_CHANGED_EVENT);
     }
 

--- a/src/lib/viz/layer/Layer.ts
+++ b/src/lib/viz/layer/Layer.ts
@@ -22,8 +22,8 @@ import { FunctionFilterApplicator } from '../filters/FunctionFilterApplicator';
 import { ColumnFilters } from '../filters/types';
 import { basicStyle } from '../style/helpers/basic-style';
 
-export const DATA_READY_EVENT = 'layerDataReady';
-export const DATA_CHANGED_EVENT = 'layerDataChanged';
+export const DATA_READY_EVENT = 'dataReady';
+export const DATA_CHANGED_EVENT = 'dataChanged';
 
 enum DATA_STATES {
   STARTING,
@@ -529,11 +529,13 @@ export class Layer extends WithEvents implements StyledLayer {
       this.dataState === DATA_STATES.STARTING &&
       (isGeoJsonLayer || referer === 'onViewportLoad')
     ) {
+      console.log(DATA_CHANGED_EVENT, DATA_READY_EVENT);
       this.emit(DATA_READY_EVENT);
       this.emit(DATA_CHANGED_EVENT);
     }
 
     if (this.dataState === DATA_STATES.UPDATING || referer === 'onViewportLoad') {
+      console.log(DATA_CHANGED_EVENT);
       this.emit(DATA_CHANGED_EVENT);
     }
 


### PR DESCRIPTION
fix https://app.clubhouse.io/cartoteam/story/92672/map-refine-map-related-data-events

The idea is to create a state object which is responsible of:
- getting event inputs: from deck instance (zoom, pan, rotate, tiles map loaded and onAfterRender)
- emitting 2 new events: 'layer:data:ready' and layer:data:changed' when is required 

The objectives are:
- solving the problems
- manage the events in one place

By now it is also emitting the previous one `viewportLoad` which is used by dataviews, but the idea is to change to the new ones.