### PR TITLE
Allow filtering of Maps API aggregated data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+- Aggregated data filtering in widgets ([#96](https://github.com/CartoDB/web-sdk/pull/96))
+
 
 ## [1.0.0-alpha.1] 2020-07-17
 

--- a/src/lib/viz/dataview/DataViewImpl.ts
+++ b/src/lib/viz/dataview/DataViewImpl.ts
@@ -6,6 +6,7 @@ import { CartoDataViewError, dataViewErrorTypes } from './DataViewError';
 
 export abstract class DataViewImpl<T> extends WithEvents {
   protected dataView: DataViewMode;
+  protected containsAggregatedData = false;
 
   public operation: AggregationType;
 
@@ -31,8 +32,16 @@ export abstract class DataViewImpl<T> extends WithEvents {
     this.dataView.column = newColumn;
   }
 
+  public getAggregationColumnName() {
+    return `_cdb_${this.operation}__${this.column}`;
+  }
+
   public addFilter(filterId: string, filter: Filter) {
-    this.dataView.addFilter(filterId, filter);
+    const filterOptions = {
+      ...(this.containsAggregatedData ? { columnName: this.getAggregationColumnName() } : {})
+    };
+
+    this.dataView.addFilter(filterId, filter, filterOptions);
   }
 
   public removeFilter(filterId: string) {

--- a/src/lib/viz/dataview/__tests__/DataViewLocal.spec.ts
+++ b/src/lib/viz/dataview/__tests__/DataViewLocal.spec.ts
@@ -1,0 +1,26 @@
+import { Layer } from '@/viz/layer';
+import { DataViewLocal } from '../mode/DataViewLocal';
+
+describe('DataViewMode', () => {
+  describe('.addFilter', () => {
+    it('should allow to override column name in filter', async () => {
+      const fakeLayer = ({
+        on: jest.fn(),
+        addField: jest.fn(),
+        addFilter: jest.fn()
+      } as unknown) as Layer;
+
+      const dataviewMode = new DataViewLocal(fakeLayer, 'fake_column');
+
+      dataviewMode.addFilter(
+        'fake_filter',
+        { within: [1, 2] },
+        { columnName: 'overridenColumnName' }
+      );
+
+      expect(fakeLayer.addFilter).toHaveBeenCalledWith('fake_filter', {
+        overridenColumnName: { within: [1, 2] }
+      });
+    });
+  });
+});

--- a/src/lib/viz/dataview/__tests__/FormulaDataViewImpl.spec.ts
+++ b/src/lib/viz/dataview/__tests__/FormulaDataViewImpl.spec.ts
@@ -1,0 +1,31 @@
+import { AggregationType } from '@/data/operations/aggregation';
+import { FormulaDataViewImpl } from '../formula/FormulaDataViewImpl';
+import { DataViewLocal } from '../mode/DataViewLocal';
+
+describe('FormulaDataViewImpl', () => {
+  describe('.addFilter', () => {
+    it('should add filter to aggregated column if data is aggregated', async () => {
+      const localDataView = ({
+        column: 'fake_column',
+        addFilter: jest.fn(),
+        availableEvents: [],
+        getSourceData() {
+          return [{ _cdb_avg__fake_column: 2, _cdb_feature_count: 1 }];
+        }
+      } as unknown) as DataViewLocal;
+
+      const dataViewImplementation = new FormulaDataViewImpl(localDataView, {
+        operation: AggregationType.AVG
+      });
+      await dataViewImplementation.getLocalData();
+
+      dataViewImplementation.addFilter('fake_filter', { within: [1, 3] });
+
+      expect(localDataView.addFilter).toHaveBeenCalledWith(
+        'fake_filter',
+        { within: [1, 3] },
+        { columnName: '_cdb_avg__fake_column' }
+      );
+    });
+  });
+});

--- a/src/lib/viz/dataview/__tests__/HistogramDataViewImpl.spec.ts
+++ b/src/lib/viz/dataview/__tests__/HistogramDataViewImpl.spec.ts
@@ -1,0 +1,34 @@
+import { HistogramDataViewImpl } from '../histogram/HistogramDataViewImpl';
+import { DataViewLocal } from '../mode/DataViewLocal';
+
+describe('HistogramDataViewImpl', () => {
+  describe('.addFilter', () => {
+    it('should add filter to aggregated column if data is aggregated', async () => {
+      const localDataView = ({
+        column: 'fake_column',
+        addFilter: jest.fn(),
+        availableEvents: [],
+        getSourceData() {
+          return [
+            { _cdb_avg__fake_column: 2, _cdb_feature_count: 1 },
+            { _cdb_avg__fake_column: 3, _cdb_feature_count: 1 },
+            { _cdb_avg__fake_column: 4, _cdb_feature_count: 1 },
+            { _cdb_avg__fake_column: 7, _cdb_feature_count: 1 },
+            { _cdb_avg__fake_column: 9, _cdb_feature_count: 1 }
+          ];
+        }
+      } as unknown) as DataViewLocal;
+
+      const dataViewImplementation = new HistogramDataViewImpl(localDataView, { bins: 5 });
+      await dataViewImplementation.getLocalData({});
+
+      dataViewImplementation.addFilter('fake_filter', { within: [1, 3] });
+
+      expect(localDataView.addFilter).toHaveBeenCalledWith(
+        'fake_filter',
+        { within: [1, 3] },
+        { columnName: '_cdb_avg__fake_column' }
+      );
+    });
+  });
+});

--- a/src/lib/viz/dataview/formula/FormulaDataViewImpl.ts
+++ b/src/lib/viz/dataview/formula/FormulaDataViewImpl.ts
@@ -24,11 +24,12 @@ export class FormulaDataViewImpl extends DataViewImpl<FormulaDataViewData> {
         }
       });
 
-      const aggregatedColumnName = `_cdb_${this.operation}__${this.column}`;
+      const aggregatedColumnName = this.getAggregationColumnName();
       const columnName = this.column;
 
       const anyFeature = features.length > 0;
       const containsAggregatedData = anyFeature ? aggregatedColumnName in features[0] : false;
+      this.containsAggregatedData = this.containsAggregatedData || containsAggregatedData;
 
       const values = containsAggregatedData
         ? features.map((feature: Record<string, unknown>) => ({

--- a/src/lib/viz/dataview/histogram/HistogramDataViewImpl.ts
+++ b/src/lib/viz/dataview/histogram/HistogramDataViewImpl.ts
@@ -30,14 +30,16 @@ export class HistogramDataViewImpl extends DataViewImpl<HistogramDataViewData> {
 
     try {
       const features = (await dataviewLocal.getSourceData(options)) as Record<string, number>[];
-      const sortedFeatures = features.map(feature => feature[this.column]).sort((a, b) => a - b);
+      const sortedFeatures = features
+        .map(feature => feature[aggregatedColumnName] || feature[columnName])
+        .sort((a, b) => a - b);
 
       const startValue = start ?? Math.min(...sortedFeatures);
       const endValue = end ?? Math.max(...sortedFeatures);
       let nulls = 0;
 
       const binsDistance = (endValue - startValue) / bins;
-      const binsNumber = Array(bins)
+      const binsContainer = Array(bins)
         .fill(bins)
         .map((_, currentIndex) => ({
           bin: currentIndex,
@@ -59,7 +61,7 @@ export class HistogramDataViewImpl extends DataViewImpl<HistogramDataViewData> {
           return;
         }
 
-        const binContainer = binsNumber.find(
+        const binContainer = binsContainer.find(
           bin => bin.start <= featureValue && bin.end > featureValue
         );
 
@@ -72,7 +74,7 @@ export class HistogramDataViewImpl extends DataViewImpl<HistogramDataViewData> {
         this.containsAggregatedData = this.containsAggregatedData || containsAggregatedData;
       });
 
-      const transformedBins = binsNumber.map(binContainer => {
+      const transformedBins = binsContainer.map(binContainer => {
         return {
           bin: binContainer.bin,
           start: binContainer.start,

--- a/src/lib/viz/dataview/histogram/HistogramDataViewImpl.ts
+++ b/src/lib/viz/dataview/histogram/HistogramDataViewImpl.ts
@@ -25,7 +25,7 @@ export class HistogramDataViewImpl extends DataViewImpl<HistogramDataViewData> {
     const dataviewLocal = this.dataView as DataViewLocal;
     const { bins = 10, start, end } = this.options;
 
-    const aggregatedColumnName = `_cdb_${this.operation}__${this.column}`;
+    const aggregatedColumnName = this.getAggregationColumnName();
     const columnName = this.column;
 
     try {
@@ -48,7 +48,7 @@ export class HistogramDataViewImpl extends DataViewImpl<HistogramDataViewData> {
         }));
 
       features.forEach(feature => {
-        const { featureValue, clusterCount } = getFeatureValue(
+        const { featureValue, clusterCount, containsAggregatedData } = getFeatureValue(
           feature,
           aggregatedColumnName,
           columnName
@@ -69,6 +69,7 @@ export class HistogramDataViewImpl extends DataViewImpl<HistogramDataViewData> {
 
         binContainer.value += clusterCount || 1;
         binContainer.values.push(featureValue);
+        this.containsAggregatedData = this.containsAggregatedData || containsAggregatedData;
       });
 
       const transformedBins = binsNumber.map(binContainer => {

--- a/src/lib/viz/dataview/mode/DataViewMode.ts
+++ b/src/lib/viz/dataview/mode/DataViewMode.ts
@@ -1,6 +1,6 @@
 import { Layer, Source } from '@/viz';
 import { WithEvents } from '@/core/mixins/WithEvents';
-import { Filter, ColumnFilters, SpatialFilters } from '@/viz/filters/types';
+import { Filter, ColumnFilters, SpatialFilters, FilterOptions } from '@/viz/filters/types';
 import { CartoDataViewError, dataViewErrorTypes } from '../DataViewError';
 
 export abstract class DataViewMode extends WithEvents {
@@ -22,8 +22,8 @@ export abstract class DataViewMode extends WithEvents {
     }
   }
 
-  public addFilter(filterId: string, filter: Filter) {
-    this.dataOrigin.addFilter(filterId, { [this.column]: filter });
+  public addFilter(filterId: string, filter: Filter, filterOptions: FilterOptions = {}) {
+    this.dataOrigin.addFilter(filterId, { [filterOptions.columnName || this.column]: filter });
   }
 
   public removeFilter(filterId: string) {

--- a/src/lib/viz/dataview/utils.ts
+++ b/src/lib/viz/dataview/utils.ts
@@ -39,12 +39,10 @@ export function getFeatureValue(
   feature: Record<string, number>,
   aggregatedColumnName: string,
   column: string
-): { featureValue: number; clusterCount: number } {
-  const clusterCount = feature[CLUSTER_COUNT_PROPERTY];
-  const featureValue = feature[aggregatedColumnName] || feature[column];
-
+): { featureValue: number; clusterCount: number; containsAggregatedData: boolean } {
   return {
-    featureValue,
-    clusterCount
+    featureValue: feature[aggregatedColumnName] || feature[column],
+    clusterCount: feature[CLUSTER_COUNT_PROPERTY],
+    containsAggregatedData: aggregatedColumnName in feature
   };
 }

--- a/src/lib/viz/filters/types.ts
+++ b/src/lib/viz/filters/types.ts
@@ -5,3 +5,7 @@ export type FilterTypes = 'in' | 'within';
 export type Filter = Dictionary<FilterTypes, string[]>;
 export type ColumnFilters = Dictionary<string, Filter>;
 export type SpatialFilters = Dictionary<SpatialFilterTypes, number[]> | 'viewport';
+
+export interface FilterOptions {
+  columnName?: string;
+}

--- a/src/lib/viz/filters/types.ts
+++ b/src/lib/viz/filters/types.ts
@@ -2,7 +2,7 @@ type Dictionary<K extends string, T> = Partial<Record<K, T>>;
 
 export type SpatialFilterTypes = 'bbox';
 export type FilterTypes = 'in' | 'within';
-export type Filter = Dictionary<FilterTypes, string[]>;
+export type Filter = Dictionary<FilterTypes, string[] | number[]>;
 export type ColumnFilters = Dictionary<string, Filter>;
 export type SpatialFilters = Dictionary<SpatialFilterTypes, number[]> | 'viewport';
 


### PR DESCRIPTION
This PR implements map filtering for data aggregated in tiles generated by Maps API.

As aggregated data has an specific column name with `_cdb_${operation}_{column}`, we didn't support filtering of those special columns until now.