### PR TITLE
fix: add version variable to esm & cjs modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix WEBSDK VERSION for .cjs & .esm module distributions ([#115](https://github.com/CartoDB/web-sdk/pull/115/))
+
 ## [1.0.0-alpha.2] 2020-07-31
 
 ### Added

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+const packagejson = require('./package.json');
+
 const COMMON_CONFIG = {
   comments: false,
   ignore: ['./declarations']
@@ -26,6 +28,12 @@ const ESM_CONFIG = {
           '@': './src/'
         }
       }
+    ],
+    [
+      'global-define',
+      {
+        WEBSDK_VERSION: packagejson.version
+      }
     ]
   ]
 };
@@ -51,6 +59,12 @@ const COMMONJS_CONFIG = {
         alias: {
           '@': './src/'
         }
+      }
+    ],
+    [
+      'global-define',
+      {
+        WEBSDK_VERSION: packagejson.version
       }
     ]
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -4473,6 +4473,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-global-define": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-global-define/-/babel-plugin-global-define-1.0.3.tgz",
+      "integrity": "sha512-M8Sby4wRLuLr+9UB8V31knVRf/rl0xkk51A7um6hUCvVPyOvLtI0u0k1OPiMgE2d7CwmeSa33NzGpaALHPQCPg==",
+      "dev": true
+    },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@typescript-eslint/parser": "^3.1.0",
     "acorn": "^7.1.1",
     "aws-sdk": "^2.709.0",
+    "babel-plugin-global-define": "^1.0.3",
     "babel-plugin-module-resolver": "^4.0.0",
     "current-git-branch": "^1.1.0",
     "eslint": "^6.8.0",


### PR DESCRIPTION
CJS & ESM modules didn't have access to WEBSDK_VERSION (like umd with webpack does)