### PR TITLE
[STYLE] Classifier helpers for viewport

### DIFF
--- a/examples/_debug/style/color-bins-style-viewport.html
+++ b/examples/_debug/style/color-bins-style-viewport.html
@@ -12,6 +12,12 @@
       href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
     />
 
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://libs.cartocdn.com/airship-style/v2.4/airship.min.css"
+    />
+
     <style>
       body {
         margin: 0;
@@ -27,9 +33,17 @@
 
   <body>
     <section id="map"></section>
+    <div class="as-map-panels">
+      <div class="as-panel as-panel--top as-panel--left">
+        <as-legend>
+          <as-legend-color-bins id="legend" slot="legends"></as-legend-color-bins>
+        </as-legend>
+      </div>
+    </div>
 
     <!-- Map libraries-->
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://libs.cartocdn.com/airship-components/v2.4/airship.js"></script>
     <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
 
     <script src="/dist/umd/index.min.js"></script>
@@ -97,6 +111,7 @@
         });
         const layer = new carto.viz.Layer('eng_wales_pop', style);
         layer.addTo(deckMap);
+        new carto.viz.Legend('#legend', layer);
       }
 
       // initializePoints();

--- a/examples/_debug/style/color-bins-style-viewport.html
+++ b/examples/_debug/style/color-bins-style-viewport.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoJSON Layer with CARTO Tiles Example</title>
+
+    <!-- Custom CSS -->
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <section id="map"></section>
+
+    <!-- Map libraries-->
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
+
+    <script src="/dist/umd/index.min.js"></script>
+
+    <script>
+      function initializePoints() {
+        carto.auth.setDefaultCredentials({ username: 'public' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -3.7003859,
+            latitude: 40.4153265,
+            zoom: 12
+          }
+        });
+
+        const style = carto.viz.style.colorBins('availability_365', {
+          bins: 5,
+          method: 'quantiles',
+          viewport: true
+          // breaks: [],
+          // palette:
+        });
+        const layer = new carto.viz.Layer('listings_madrid', style);
+        layer.addTo(deckMap);
+      }
+
+      function initializeLines() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: 135.7,
+            latitude: -25.48,
+            zoom: 3
+          }
+        });
+
+        const style = carto.viz.style.colorBins('length_km');
+        const layer = new carto.viz.Layer('roads', style);
+        layer.addTo(deckMap);
+      }
+
+      function initializePolygons() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -2.6806640625,
+            latitude: 53.48804553605622,
+            zoom: 6
+          }
+        });
+
+        const style = carto.viz.style.colorBins('pop_sq_km', {
+          viewport: true,
+          // method: 'quantiles'
+          method: 'stdev'
+          // method: 'equal'
+          // color: '#0000FF',
+          // size: 5
+        });
+        const layer = new carto.viz.Layer('eng_wales_pop', style);
+        layer.addTo(deckMap);
+      }
+
+      // initializePoints();
+      // initializeLines();
+      initializePolygons();
+    </script>
+  </body>
+</html>

--- a/examples/_debug/style/color-categories-style-viewport.html
+++ b/examples/_debug/style/color-categories-style-viewport.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoJSON Layer with CARTO Tiles Example</title>
+
+    <!-- Custom CSS -->
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <section id="map"></section>
+
+    <!-- Map libraries-->
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
+
+    <script src="/dist/umd/index.min.js"></script>
+
+    <script>
+      function initializePoints() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -122.45292663574217,
+            latitude: 37.760944207425965,
+            zoom: 11
+          }
+        });
+
+        const style = carto.viz.style.colorCategories('category');
+        const layer = new carto.viz.Layer('sf_nbhd_crime', style);
+        layer.addTo(deckMap);
+      }
+
+      function initializeLines() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: 135.7,
+            latitude: -25.48,
+            zoom: 3
+          }
+        });
+
+        const style = carto.viz.style.colorCategories('type');
+        const layer = new carto.viz.Layer('roads', style);
+        layer.addTo(deckMap);
+      }
+
+      function initializePolygons() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -73.96176338195801,
+            latitude: 40.71402088381144,
+            zoom: 14
+          }
+        });
+
+        const style = carto.viz.style.colorCategories('landuse_type', { viewport: true });
+        const layer = new carto.viz.Layer('wburg_parcels', style);
+        layer.addTo(deckMap);
+      }
+
+      function initializePolygons2() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -2.6806640625,
+            latitude: 53.48804553605622,
+            zoom: 6
+          }
+        });
+
+        const style = carto.viz.style.colorCategories('region', {
+          // color: '#0000FF',
+          // size: 5
+        });
+        const layer = new carto.viz.Layer('eng_wales_pop', style);
+        layer.addTo(deckMap);
+      }
+
+      // initializePoints();
+      initializePolygons();
+      // initializeLines();
+      // initializePolygons2();
+    </script>
+  </body>
+</html>

--- a/examples/_debug/style/color-categories-style-viewport.html
+++ b/examples/_debug/style/color-categories-style-viewport.html
@@ -11,6 +11,11 @@
       type="text/css"
       href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://libs.cartocdn.com/airship-style/v2.4/airship.min.css"
+    />
 
     <style>
       body {
@@ -27,9 +32,17 @@
 
   <body>
     <section id="map"></section>
+    <div class="as-map-panels">
+      <div class="as-panel as-panel--top as-panel--left">
+        <as-legend>
+          <as-legend-color-category id="legend" slot="legends"></as-legend-color-category>
+        </as-legend>
+      </div>
+    </div>
 
     <!-- Map libraries-->
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://libs.cartocdn.com/airship-components/v2.4/airship.js"></script>
     <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
 
     <script src="/dist/umd/index.min.js"></script>
@@ -84,6 +97,7 @@
         const style = carto.viz.style.colorCategories('landuse_type', { viewport: true });
         const layer = new carto.viz.Layer('wburg_parcels', style);
         layer.addTo(deckMap);
+        new carto.viz.Legend('#legend', layer);
       }
 
       function initializePolygons2() {

--- a/examples/_debug/style/color-continuous-style-viewport.html
+++ b/examples/_debug/style/color-continuous-style-viewport.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoJSON Layer with CARTO Tiles Example</title>
+
+    <!-- Custom CSS -->
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <section id="map"></section>
+
+    <!-- Map libraries-->
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
+
+    <script src="/dist/umd/index.min.js"></script>
+
+    <script>
+      async function initialize() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -116.846099,
+            latitude: 50.2672297,
+            zoom: 2.5
+          }
+        });
+
+        const style = carto.viz.style.colorContinuous('value', { viewport: true });
+        const tempLayer = new carto.viz.Layer('temps', style);
+        tempLayer.addTo(deckMap);
+      }
+
+      async function initializePolygons() {
+        carto.auth.setDefaultCredentials({ username: 'josemacarto' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -122.45292663574217,
+            latitude: 37.760944207425965,
+            zoom: 11
+          }
+        });
+
+        const style = carto.viz.style.colorContinuous('businesses', { viewport: true });
+        const tempLayer = new carto.viz.Layer('sf_businesses_neighborhoods', style);
+        tempLayer.addTo(deckMap);
+      }
+
+      initialize();
+      // initializePolygons();
+    </script>
+  </body>
+</html>

--- a/examples/_debug/style/color-continuous-style-viewport.html
+++ b/examples/_debug/style/color-continuous-style-viewport.html
@@ -11,6 +11,11 @@
       type="text/css"
       href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://libs.cartocdn.com/airship-style/v2.4/airship.min.css"
+    />
 
     <style>
       body {
@@ -27,9 +32,17 @@
 
   <body>
     <section id="map"></section>
+    <div class="as-map-panels">
+      <div class="as-panel as-panel--top as-panel--left">
+        <as-legend>
+          <as-legend-color-continuous id="legend" slot="legends"></as-legend-color-continuous>
+        </as-legend>
+      </div>
+    </div>
 
     <!-- Map libraries-->
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://libs.cartocdn.com/airship-components/v2.4/airship.js"></script>
     <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
 
     <script src="/dist/umd/index.min.js"></script>
@@ -50,6 +63,7 @@
         const style = carto.viz.style.colorContinuous('value', { viewport: true });
         const tempLayer = new carto.viz.Layer('temps', style);
         tempLayer.addTo(deckMap);
+        new carto.viz.Legend('#legend', tempLayer);
       }
 
       async function initializePolygons() {

--- a/examples/_debug/style/size-bins-style-viewport.html
+++ b/examples/_debug/style/size-bins-style-viewport.html
@@ -11,6 +11,11 @@
       type="text/css"
       href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://libs.cartocdn.com/airship-style/v2.4/airship.min.css"
+    />
 
     <style>
       body {
@@ -27,9 +32,17 @@
 
   <body>
     <section id="map"></section>
+    <div class="as-map-panels">
+      <div class="as-panel as-panel--top as-panel--left">
+        <as-legend>
+          <as-legend-size-bins id="legend" slot="legends"></as-legend-size-bins>
+        </as-legend>
+      </div>
+    </div>
 
     <!-- Map libraries-->
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://libs.cartocdn.com/airship-components/v2.4/airship.js"></script>
     <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
 
     <script src="/dist/umd/index.min.js"></script>
@@ -53,6 +66,7 @@
         });
         const layer = new carto.viz.Layer('clev_sales', style);
         layer.addTo(deckMap);
+        new carto.viz.Legend('#legend', layer);
       }
 
       function initializeLines() {

--- a/examples/_debug/style/size-bins-style-viewport.html
+++ b/examples/_debug/style/size-bins-style-viewport.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoJSON Layer with CARTO Tiles Example</title>
+
+    <!-- Custom CSS -->
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <section id="map"></section>
+
+    <!-- Map libraries-->
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
+
+    <script src="/dist/umd/index.min.js"></script>
+
+    <script>
+      function initializePoints() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -81.6830062866211,
+            latitude: 41.49057783237735,
+            zoom: 11
+          }
+        });
+
+        const style = carto.viz.style.sizeBins('sale_price', {
+          viewport: true
+          // bins: 3
+        });
+        const layer = new carto.viz.Layer('clev_sales', style);
+        layer.addTo(deckMap);
+      }
+
+      function initializeLines() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: 135.7,
+            latitude: -25.48,
+            zoom: 3
+          }
+        });
+
+        const style = carto.viz.style.sizeBins('length_km', {
+          bins: 3,
+          sizeRange: [1, 5]
+        });
+        const layer = new carto.viz.Layer('roads', style);
+        layer.addTo(deckMap);
+      }
+
+      initializePoints();
+      // initializeLines();
+    </script>
+  </body>
+</html>

--- a/examples/_debug/style/size-categories-style-viewport.html
+++ b/examples/_debug/style/size-categories-style-viewport.html
@@ -11,6 +11,11 @@
       type="text/css"
       href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://libs.cartocdn.com/airship-style/v2.4/airship.min.css"
+    />
 
     <style>
       body {
@@ -27,9 +32,17 @@
 
   <body>
     <section id="map"></section>
+    <div class="as-map-panels">
+      <div class="as-panel as-panel--top as-panel--left">
+        <as-legend>
+          <as-legend-size-category id="legend" slot="legends"></as-legend-size-category>
+        </as-legend>
+      </div>
+    </div>
 
     <!-- Map libraries-->
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://libs.cartocdn.com/airship-components/v2.4/airship.js"></script>
     <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
 
     <script src="/dist/umd/index.min.js"></script>
@@ -50,6 +63,7 @@
         const style = carto.viz.style.sizeCategories('incident_day_of_week', { viewport: true });
         const layer = new carto.viz.Layer('sf_incidents', style);
         layer.addTo(deckMap);
+        new carto.viz.Legend('#legend', layer);
       }
 
       function initializeLines() {

--- a/examples/_debug/style/size-categories-style-viewport.html
+++ b/examples/_debug/style/size-categories-style-viewport.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoJSON Layer with CARTO Tiles Example</title>
+
+    <!-- Custom CSS -->
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <section id="map"></section>
+
+    <!-- Map libraries-->
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
+
+    <script src="/dist/umd/index.min.js"></script>
+
+    <script>
+      function initializePoints() {
+        carto.auth.setDefaultCredentials({ username: 'josemacarto' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -122.45292663574217,
+            latitude: 37.760944207425965,
+            zoom: 11
+          }
+        });
+
+        const style = carto.viz.style.sizeCategories('incident_day_of_week', { viewport: true });
+        const layer = new carto.viz.Layer('sf_incidents', style);
+        layer.addTo(deckMap);
+      }
+
+      function initializeLines() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: 135.7,
+            latitude: -25.48,
+            zoom: 3
+          }
+        });
+
+        const style = carto.viz.style.sizeCategories('type', { viewport: true });
+
+        const source = new carto.viz.source.Dataset('roads', {
+          mapOptions: {
+            bufferSize: {
+              mvt: 30
+            }
+          }
+        });
+        const layer = new carto.viz.Layer(source, style);
+        layer.addTo(deckMap);
+      }
+
+      initializePoints();
+      // initializeLines();
+    </script>
+  </body>
+</html>

--- a/examples/_debug/style/size-continuous-style-viewport.html
+++ b/examples/_debug/style/size-continuous-style-viewport.html
@@ -11,6 +11,11 @@
       type="text/css"
       href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://libs.cartocdn.com/airship-style/v2.4/airship.min.css"
+    />
 
     <style>
       body {
@@ -27,9 +32,17 @@
 
   <body>
     <section id="map"></section>
+    <div class="as-map-panels">
+      <div class="as-panel as-panel--top as-panel--left">
+        <as-legend>
+          <as-legend-size-continuous id="legend" slot="legends"></as-legend-size-continuous>
+        </as-legend>
+      </div>
+    </div>
 
     <!-- Map libraries-->
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://libs.cartocdn.com/airship-components/v2.4/airship.js"></script>
     <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
 
     <script src="/dist/umd/index.min.js"></script>
@@ -57,6 +70,7 @@
 
         const tempLayer = new carto.viz.Layer('ca_measures', style);
         tempLayer.addTo(deckMap);
+        new carto.viz.Legend('#legend', tempLayer);
       }
 
       initialize();

--- a/examples/_debug/style/size-continuous-style-viewport.html
+++ b/examples/_debug/style/size-continuous-style-viewport.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoJSON Layer with CARTO Tiles Example</title>
+
+    <!-- Custom CSS -->
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.css"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <section id="map"></section>
+
+    <!-- Map libraries-->
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.2.0/dist.min.js"></script>
+
+    <script src="/dist/umd/index.min.js"></script>
+
+    <script>
+      async function initialize() {
+        carto.auth.setDefaultCredentials({ username: 'cartoframes' });
+
+        const deckMap = carto.viz.createMap({
+          basemap: 'voyager',
+          view: {
+            longitude: -116.846099,
+            latitude: 50.2672297,
+            zoom: 2.5
+          }
+        });
+
+        const style = carto.viz.style.sizeContinuous('total_pop', {
+          sizeRange: [5, 50],
+          color: '#0000FF',
+          strokeColor: '#40E0D0',
+          strokeWidth: 1,
+          viewport: true
+        });
+
+        const tempLayer = new carto.viz.Layer('ca_measures', style);
+        tempLayer.addTo(deckMap);
+      }
+
+      initialize();
+    </script>
+  </body>
+</html>

--- a/src/viz/__tests__/Classifier.spec.ts
+++ b/src/viz/__tests__/Classifier.spec.ts
@@ -19,8 +19,8 @@ describe('Classifier', () => {
   describe('Classifier methods', () => {
     const classifier = new Classifier(stats);
 
-    it('Quantiles', () => {
-      const breaks = classifier.breaks(4, 'quantiles');
+    it('Quantiles', async () => {
+      const breaks = await classifier.breaks(4, 'quantiles');
       const expectedBreaks = [
         40.6120458424774,
         46.377123199312,
@@ -30,8 +30,8 @@ describe('Classifier', () => {
       expect(breaks).toMatchObject(expectedBreaks);
     });
 
-    it('Equal', () => {
-      const breaks = classifier.breaks(4, 'equal');
+    it('Equal', async () => {
+      const breaks = await classifier.breaks(4, 'equal');
       const expectedBreaks = [
         34.65714291396062,
         47.96506670056654,
@@ -41,8 +41,8 @@ describe('Classifier', () => {
       expect(breaks).toMatchObject(expectedBreaks);
     });
 
-    it('StandardDev', () => {
-      const breaks = classifier.breaks(4, 'stdev');
+    it('StandardDev', async () => {
+      const breaks = await classifier.breaks(4, 'stdev');
       const expectedBreaks = [
         28.762902879178785,
         39.44729714406859,

--- a/src/viz/__tests__/Layer.spec.ts
+++ b/src/viz/__tests__/Layer.spec.ts
@@ -186,7 +186,7 @@ describe('Layer', () => {
       DatasetSource.prototype.getProps = mockSourceGetProps;
       DatasetSource.prototype.getMetadata = mockSourceGetMetadata;
       Layer.prototype.getStyle = jest.fn().mockImplementation(() => {
-        return new Style({});
+        return new Promise(complete => complete(new Style({})));
       });
     });
 

--- a/src/viz/__tests__/styles/BasicStyle.spec.ts
+++ b/src/viz/__tests__/styles/BasicStyle.spec.ts
@@ -28,13 +28,13 @@ describe('BasicStyle', () => {
   });
 
   describe('Parameters', () => {
-    it('should assign defaultsStyles', () => {
+    it('should assign defaultsStyles', async () => {
       const style = basicStyle();
-      const r = style.getLayerProps(styledLayer);
+      const r = await style.getLayerProps(styledLayer);
       expect(r.getFillColor).toEqual(hexToRgb(defaultStyles.Polygon.color));
     });
 
-    it('should assign provided varaiables', () => {
+    it('should assign provided varaiables', async () => {
       const opts = {
         color: '#123',
         strokeColor: '#456',
@@ -42,7 +42,7 @@ describe('BasicStyle', () => {
         strokeWidth: 2
       };
       const style = basicStyle(opts);
-      const r = style.getLayerProps(styledLayer);
+      const r = await style.getLayerProps(styledLayer);
       expect(r.getFillColor).toEqual(hexToRgb(opts.color));
       expect(r.getLineColor).toEqual(hexToRgb(opts.strokeColor));
       expect(r.getLineWidth).toEqual(opts.strokeWidth);

--- a/src/viz/__tests__/styles/ColorBinsStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorBinsStyle.spec.ts
@@ -37,9 +37,9 @@ describe('ColorBinsStyle', () => {
       expect(() => colorBinsStyle('attributeName')).not.toThrow();
     });
 
-    it('should always return a getFillColor function', () => {
+    it('should always return a getFillColor function', async () => {
       const style = colorBinsStyle(FIELD_NAME);
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getFillColor');
       expect(response.getFillColor).toBeInstanceOf(Function);
     });
@@ -132,16 +132,16 @@ describe('ColorBinsStyle', () => {
       }
     });
 
-    it('If geometryType is Polygon and property is strokeColor getLineColor should be a function', () => {
+    it('If geometryType is Polygon and property is strokeColor getLineColor should be a function', async () => {
       const style = colorBinsStyle(FIELD_NAME, {
         property: 'strokeColor'
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineColor');
       expect(response.getLineColor).toBeInstanceOf(Function);
     });
 
-    it('If geometryType is Point and property is strokeColor getLineColor should be a function', () => {
+    it('If geometryType is Point and property is strokeColor getLineColor should be a function', async () => {
       const style = colorBinsStyle(FIELD_NAME, {
         property: 'strokeColor'
       });
@@ -152,14 +152,14 @@ describe('ColorBinsStyle', () => {
           stats: [stats]
         };
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineColor');
       expect(response.getLineColor).toBeInstanceOf(Function);
     });
   });
 
   describe('Data validation', () => {
-    describe('Custom breaks', () => {
+    describe('Custom breaks', async () => {
       const palette = ['#000', '#111', '#222', '#333', '#444', '#555'];
       const nullColor = '#f00';
       const style = colorBinsStyle(FIELD_NAME, {
@@ -167,7 +167,7 @@ describe('ColorBinsStyle', () => {
         palette,
         nullColor
       });
-      const getFillColor = style.getLayerProps(styledLayer).getFillColor as (d: any) => any;
+      const getFillColor = (await style.getLayerProps(styledLayer)).getFillColor as (d: any) => any;
 
       it('should assign the right color to feature between intervals', () => {
         const r = getFillColor({ properties: { [FIELD_NAME]: 30 } });
@@ -195,10 +195,10 @@ describe('ColorBinsStyle', () => {
       });
     });
 
-    describe('With defaults', () => {
+    describe('With defaults', async () => {
       const palette = ['#000', '#111', '#222', '#333', '#444'];
       const style = colorBinsStyle(FIELD_NAME, { palette });
-      const getFillColor = style.getLayerProps(styledLayer).getFillColor as (d: any) => any;
+      const getFillColor = (await style.getLayerProps(styledLayer)).getFillColor as (d: any) => any;
 
       it('should assign the right color to feature using dynamic breaks', () => {
         const r = getFillColor({ properties: { [FIELD_NAME]: stats.avg } });

--- a/src/viz/__tests__/styles/ColorCategoriesStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorCategoriesStyle.spec.ts
@@ -38,9 +38,9 @@ describe('ColorCategoriesStyle', () => {
       expect(() => colorCategoriesStyle('attributeName')).not.toThrow();
     });
 
-    it('should always return a getFillColor function', () => {
+    it('should always return a getFillColor function', async () => {
       const style = colorCategoriesStyle(FIELD_NAME);
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getFillColor');
       expect(response.getFillColor).toBeInstanceOf(Function);
     });
@@ -128,7 +128,7 @@ describe('ColorCategoriesStyle', () => {
       }
     });
 
-    it('If geometryType is Polygon and property is strokeColor getLineColor should be a function', () => {
+    it('If geometryType is Polygon and property is strokeColor getLineColor should be a function', async () => {
       const style = colorCategoriesStyle(FIELD_NAME, {
         property: 'strokeColor'
       });
@@ -144,22 +144,22 @@ describe('ColorCategoriesStyle', () => {
           ]
         };
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineColor');
       expect(response.getLineColor).toBeInstanceOf(Function);
     });
 
-    it('If geometryType is Point and property is strokeColor getLineColor should be a function', () => {
+    it('If geometryType is Point and property is strokeColor getLineColor should be a function', async () => {
       const style = colorCategoriesStyle(FIELD_NAME, {
         property: 'strokeColor'
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineColor');
       expect(response.getLineColor).toBeInstanceOf(Function);
     });
   });
 
-  describe('Data validation', () => {
+  describe('Data validation', async () => {
     const opts = {
       categories: ['Moda y calzado', 'Bares y restaurantes', 'Salud'],
       palette: ['#000', '#111', '#222'],
@@ -169,7 +169,7 @@ describe('ColorCategoriesStyle', () => {
 
     const style = colorCategoriesStyle(FIELD_NAME, opts);
 
-    let getFillColor = style.getLayerProps(styledLayer).getFillColor as (d: any) => any;
+    let getFillColor = (await style.getLayerProps(styledLayer)).getFillColor as (d: any) => any;
 
     it('should assign the right color to a category', () => {
       const r = getFillColor({
@@ -190,11 +190,11 @@ describe('ColorCategoriesStyle', () => {
       expect(r).toEqual(hexToRgb(opts.nullColor));
     });
 
-    it('should assign the right color when top defined', () => {
+    it('should assign the right color when top defined', async () => {
       const top = 1;
       const s = colorCategoriesStyle(FIELD_NAME, { ...opts, top });
 
-      getFillColor = s.getLayerProps(styledLayer).getFillColor as (d: any) => any;
+      getFillColor = (await s.getLayerProps(styledLayer)).getFillColor as (d: any) => any;
 
       const r = getFillColor({
         properties: { [FIELD_NAME]: 'Bares y restaurantes' }
@@ -202,9 +202,9 @@ describe('ColorCategoriesStyle', () => {
       expect(r).toEqual(hexToRgb(opts.othersColor));
     });
 
-    it('should assign the right color to feature using dynamic categories', () => {
+    it('should assign the right color to feature using dynamic categories', async () => {
       const colors = getColors(DEFAULT_PALETTE, 5);
-      const response = colorCategoriesStyle(FIELD_NAME).getLayerProps(styledLayer);
+      const response = await colorCategoriesStyle(FIELD_NAME).getLayerProps(styledLayer);
       getFillColor = response.getFillColor as (d: any) => any;
       const r = getFillColor({
         properties: { [FIELD_NAME]: 'Moda y calzado' }

--- a/src/viz/__tests__/styles/ColorContinuousStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorContinuousStyle.spec.ts
@@ -37,9 +37,9 @@ describe('ColorContinuousStyle', () => {
       expect(() => colorContinuousStyle('attributeName')).not.toThrow();
     });
 
-    it('should always return a getFillColor function', () => {
+    it('should always return a getFillColor function', async () => {
       const style = colorContinuousStyle(FIELD_NAME);
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getFillColor');
       expect(response.getFillColor).toBeInstanceOf(Function);
     });
@@ -83,16 +83,16 @@ describe('ColorContinuousStyle', () => {
       }
     });
 
-    it('If geometryType is Polygon and property is strokeColor getLineColor should be a function', () => {
+    it('If geometryType is Polygon and property is strokeColor getLineColor should be a function', async () => {
       const style = colorContinuousStyle(FIELD_NAME, {
         property: 'strokeColor'
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineColor');
       expect(response.getLineColor).toBeInstanceOf(Function);
     });
 
-    it('If geometryType is Point and property is strokeColor getLineColor should be a function', () => {
+    it('If geometryType is Point and property is strokeColor getLineColor should be a function', async () => {
       const style = colorContinuousStyle(FIELD_NAME, {
         property: 'strokeColor'
       });
@@ -103,19 +103,19 @@ describe('ColorContinuousStyle', () => {
           stats: [stats]
         };
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineColor');
       expect(response.getLineColor).toBeInstanceOf(Function);
     });
   });
 
-  describe('Data validation', () => {
+  describe('Data validation', async () => {
     const opts = {
       palette: ['#f00', '#00f', '#aff'],
       nullColor: '#0f0'
     };
     const style = colorContinuousStyle(FIELD_NAME, opts);
-    let getFillColor = style.getLayerProps(styledLayer).getFillColor as (d: any) => any;
+    let getFillColor = (await style.getLayerProps(styledLayer)).getFillColor as (d: any) => any;
 
     it('should assign the right color to a feature', () => {
       const featureValue = 30;
@@ -134,7 +134,7 @@ describe('ColorContinuousStyle', () => {
       expect(r).toEqual(hexToRgb(opts.nullColor));
     });
 
-    it('should assign the right color to a feature using ranges', () => {
+    it('should assign the right color to a feature using ranges', async () => {
       const rangeMin = 0;
       const rangeMax = 100;
       const featureValue = 30;
@@ -143,7 +143,7 @@ describe('ColorContinuousStyle', () => {
         rangeMin,
         rangeMax
       });
-      getFillColor = s.getLayerProps(styledLayer).getFillColor as (d: any) => any;
+      getFillColor = (await s.getLayerProps(styledLayer)).getFillColor as (d: any) => any;
 
       const expectedColor = chromaScale(opts.palette)
         .domain([rangeMin, rangeMax])

--- a/src/viz/__tests__/styles/SizeBinsStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeBinsStyle.spec.ts
@@ -37,9 +37,9 @@ describe('SizeBinsStyle', () => {
       expect(() => sizeBinsStyle('attributeName')).not.toThrow();
     });
 
-    it('should always return the right propertie for points', () => {
+    it('should always return the right propertie for points', async () => {
       const style = sizeBinsStyle(FIELD_NAME);
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getRadius');
       expect(response.getRadius).toBeInstanceOf(Function);
       expect(response).toHaveProperty('radiusUnits', 'pixels');
@@ -138,24 +138,24 @@ describe('SizeBinsStyle', () => {
       }
     });
 
-    it('If geometryType is Point and property is strokeWidth getLineWidth should be a function', () => {
+    it('If geometryType is Point and property is strokeWidth getLineWidth should be a function', async () => {
       const style = sizeBinsStyle(FIELD_NAME, {
         property: 'strokeWidth'
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineWidth');
       expect(response.getLineWidth).toBeInstanceOf(Function);
     });
   });
 
-  describe('Data validation', () => {
+  describe('Data validation', async () => {
     const opts = {
       breaks: [2, 4, 8, 10, 12],
       method: 'equal' as ClassificationMethod,
       sizeRange: [2, 12]
     };
     const style = sizeBinsStyle(FIELD_NAME, opts);
-    const getRadius = style.getLayerProps(styledLayer).getRadius as (d: any) => any;
+    const getRadius = (await style.getLayerProps(styledLayer)).getRadius as (d: any) => any;
 
     it('should assign the maximum size to a value at the upper limit', () => {
       const fv = opts.sizeRange[1];
@@ -194,10 +194,10 @@ describe('SizeBinsStyle', () => {
       expect(r).toEqual(opts.sizeRange[0]);
     });
 
-    it('should assign the right size to feature using dynamic breaks', () => {
+    it('should assign the right size to feature using dynamic breaks', async () => {
       const s = sizeBinsStyle(FIELD_NAME);
 
-      const getRadiusFn = s.getLayerProps(styledLayer).getRadius as (d: any) => any;
+      const getRadiusFn = (await s.getLayerProps(styledLayer)).getRadius as (d: any) => any;
 
       let r = getRadiusFn({ properties: { [FIELD_NAME]: stats.max } });
       expect(r).toEqual(defaultStyles.Point.sizeRange[1]);

--- a/src/viz/__tests__/styles/SizeCategoriesStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeCategoriesStyle.spec.ts
@@ -37,9 +37,9 @@ describe('SizeCategoriesStyle', () => {
       expect(() => sizeCategoriesStyle(FIELD_NAME)).not.toThrow();
     });
 
-    it('should always return the right propertie for points', () => {
+    it('should always return the right propertie for points', async () => {
       const style = sizeCategoriesStyle(FIELD_NAME);
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getRadius');
       expect(response.getRadius).toBeInstanceOf(Function);
       expect(response).toHaveProperty('radiusUnits', 'pixels');
@@ -124,17 +124,17 @@ describe('SizeCategoriesStyle', () => {
       }
     });
 
-    it('If geometryType is Point and property is strokeWidth getLineWidth should be a function', () => {
+    it('If geometryType is Point and property is strokeWidth getLineWidth should be a function', async () => {
       const style = sizeCategoriesStyle(FIELD_NAME, {
         property: 'strokeWidth'
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineWidth');
       expect(response.getLineWidth).toBeInstanceOf(Function);
     });
   });
 
-  describe('Data validation', () => {
+  describe('Data validation', async () => {
     const opts = {
       categories: ['Moda y calzado', 'Bares y restaurantes', 'Salud'],
       sizeRange: [2, 10]
@@ -142,7 +142,7 @@ describe('SizeCategoriesStyle', () => {
 
     const style = sizeCategoriesStyle(FIELD_NAME, opts);
 
-    let getRadius = style.getLayerProps(styledLayer).getRadius as (d: any) => any;
+    let getRadius = (await style.getLayerProps(styledLayer)).getRadius as (d: any) => any;
 
     it('should assign the right size to each category', () => {
       let r = getRadius({
@@ -169,8 +169,8 @@ describe('SizeCategoriesStyle', () => {
       expect(r).toEqual(2);
     });
 
-    it('should assign the right color to feature using dynamic categories', () => {
-      const response = sizeCategoriesStyle(FIELD_NAME).getLayerProps(styledLayer);
+    it('should assign the right color to feature using dynamic categories', async () => {
+      const response = await (await sizeCategoriesStyle(FIELD_NAME)).getLayerProps(styledLayer);
       getRadius = response.getRadius as (d: any) => any;
       let r = getRadius({
         properties: { [FIELD_NAME]: opts.categories[0] }

--- a/src/viz/__tests__/styles/SizeContinuousStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeContinuousStyle.spec.ts
@@ -36,9 +36,9 @@ describe('SizeContinuousStyle', () => {
       expect(() => sizeContinuousStyle(FIELD_NAME)).not.toThrow();
     });
 
-    it('should always return the right propertie for points', () => {
+    it('should always return the right propertie for points', async () => {
       const style = sizeContinuousStyle(FIELD_NAME);
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getRadius');
       expect(response.getRadius).toBeInstanceOf(Function);
       expect(response).toHaveProperty('radiusUnits', 'pixels');
@@ -112,23 +112,23 @@ describe('SizeContinuousStyle', () => {
       }
     });
 
-    it('If geometryType is Point and property is strokeWidth getLineWidth should be a function', () => {
+    it('If geometryType is Point and property is strokeWidth getLineWidth should be a function', async () => {
       const style = sizeContinuousStyle(FIELD_NAME, {
         property: 'strokeWidth'
       });
-      const response = style.getLayerProps(styledLayer);
+      const response = await style.getLayerProps(styledLayer);
       expect(response).toHaveProperty('getLineWidth');
       expect(response.getLineWidth).toBeInstanceOf(Function);
     });
   });
 
-  describe('Data validation', () => {
+  describe('Data validation', async () => {
     const opts = {
       sizeRange: [2, 14]
     };
 
     const style = sizeContinuousStyle(FIELD_NAME, opts);
-    let getRadius = style.getLayerProps(styledLayer).getRadius as (d: any) => any;
+    let getRadius = (await style.getLayerProps(styledLayer)).getRadius as (d: any) => any;
 
     it('should assign the right size to a feature', () => {
       let r = getRadius({ properties: { [FIELD_NAME]: stats.max } });
@@ -146,7 +146,7 @@ describe('SizeContinuousStyle', () => {
       expect(r).toEqual(0);
     });
 
-    it('should assign the right color to a feature using ranges', () => {
+    it('should assign the right color to a feature using ranges', async () => {
       const rangeMin = 0;
       const rangeMax = 100;
       const featureValue = 30;
@@ -155,7 +155,7 @@ describe('SizeContinuousStyle', () => {
         rangeMin,
         rangeMax
       });
-      getRadius = s.getLayerProps(styledLayer).getRadius as (d: any) => any;
+      getRadius = (await s.getLayerProps(styledLayer)).getRadius as (d: any) => any;
 
       const r = getRadius({ properties: { [FIELD_NAME]: featureValue } });
       expect(r).toBeCloseTo(8.5726);

--- a/src/viz/__tests__/styles/Style.spec.ts
+++ b/src/viz/__tests__/styles/Style.spec.ts
@@ -15,14 +15,14 @@ describe('Style', () => {
   });
 
   describe('getLayerProps', () => {
-    it('should return style properties', () => {
+    it('should return style properties', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const styleProperties: GeoJsonLayerProps<any> = {
         getFillColor: [0, 0, 0, 0]
       };
 
       const styleInstance = new Style(styleProperties);
-      expect(styleInstance.getLayerProps()).toMatchObject({
+      expect(await styleInstance.getLayerProps()).toMatchObject({
         getFillColor: expect.arrayContaining([0, 0, 0, 0])
       });
     });

--- a/src/viz/layer/Layer.ts
+++ b/src/viz/layer/Layer.ts
@@ -152,8 +152,9 @@ export class Layer extends WithEvents implements StyledLayer {
    * @public
    * Retrieves the legend data from the style of the layer
    */
-  public getLegendData(options = {}) {
-    return this._style.getLegendProps(this, options);
+  public async getLegendData(options = {}) {
+    const legendProps = await this._style.getLegendProps(this, options);
+    return legendProps;
   }
 
   /**

--- a/src/viz/layer/LayerInteractivity.ts
+++ b/src/viz/layer/LayerInteractivity.ts
@@ -175,7 +175,7 @@ export class LayerInteractivity {
     const wrapInteractiveStyle = { updateTriggers: {} };
 
     const currentStyle = await this._layerGetStyleFn();
-    const styleProps = currentStyle.getLayerProps(this._layer);
+    const styleProps = await currentStyle.getLayerProps(this._layer);
 
     let clickStyleProps = {};
 
@@ -183,7 +183,7 @@ export class LayerInteractivity {
       const defaultHighlightStyle = await this._getDefaultHighlightStyle();
       clickStyleProps = await defaultHighlightStyle.getLayerProps(this._layer);
     } else if (this._clickStyle instanceof Style) {
-      clickStyleProps = this._clickStyle.getLayerProps(this._layer);
+      clickStyleProps = await this._clickStyle.getLayerProps(this._layer);
     }
 
     let hoverStyleProps = {};
@@ -192,7 +192,7 @@ export class LayerInteractivity {
       const defaultHighlightStyle = await this._getDefaultHighlightStyle();
       hoverStyleProps = await defaultHighlightStyle.getLayerProps(this._layer);
     } else if (this._hoverStyle instanceof Style) {
-      hoverStyleProps = this._hoverStyle.getLayerProps(this._layer);
+      hoverStyleProps = await this._hoverStyle.getLayerProps(this._layer);
     }
 
     Object.keys({

--- a/src/viz/layer/LayerInteractivity.ts
+++ b/src/viz/layer/LayerInteractivity.ts
@@ -15,7 +15,7 @@ export class LayerInteractivity {
   private _hoverStyle?: Style | string;
   private _clickStyle?: Style | string;
 
-  private _layerGetStyleFn: () => Style;
+  private _layerGetStyleFn: () => Promise<Style>;
   private _layerSetStyleFn: (style: Style) => Promise<void>;
 
   private _layerOnFn: EventHandler;
@@ -42,15 +42,17 @@ export class LayerInteractivity {
 
     if (this._clickStyle) {
       this._layerOnFn(InteractivityEvent.CLICK, () => {
-        const interactiveStyle = this._wrapInteractiveStyle();
-        this._layerSetStyleFn(interactiveStyle);
+        this._wrapInteractiveStyle().then(interactiveStyle =>
+          this._layerSetStyleFn(interactiveStyle)
+        );
       });
     }
 
     if (this._hoverStyle) {
       this._layerOnFn(InteractivityEvent.HOVER, () => {
-        const interactiveStyle = this._wrapInteractiveStyle();
-        this._layerSetStyleFn(interactiveStyle);
+        this._wrapInteractiveStyle().then(interactiveStyle =>
+          this._layerSetStyleFn(interactiveStyle)
+        );
       });
     }
 
@@ -65,7 +67,7 @@ export class LayerInteractivity {
     this.fireOnEvent(InteractivityEvent.HOVER, info, event);
   }
 
-  public fireOnEvent(eventType: InteractivityEvent, info: any, event: HammerInput) {
+  public async fireOnEvent(eventType: InteractivityEvent, info: any, event: HammerInput) {
     const features = [];
     const { coordinate, object } = info;
 
@@ -81,7 +83,7 @@ export class LayerInteractivity {
     }
 
     if (this._clickStyle || this._hoverStyle) {
-      const interactiveStyle = this._wrapInteractiveStyle();
+      const interactiveStyle = await this._wrapInteractiveStyle();
       this._layerSetStyleFn(interactiveStyle);
     }
 
@@ -169,17 +171,17 @@ export class LayerInteractivity {
    * to check if the feature received by paramter has been clicked
    * or hovered by the user in order to apply the interaction style
    */
-  private _wrapInteractiveStyle() {
+  private async _wrapInteractiveStyle() {
     const wrapInteractiveStyle = { updateTriggers: {} };
 
-    const currentStyle = this._layerGetStyleFn();
+    const currentStyle = await this._layerGetStyleFn();
     const styleProps = currentStyle.getLayerProps(this._layer);
 
     let clickStyleProps = {};
 
     if (this._clickStyle === 'default') {
-      const defaultHighlightStyle = this._getDefaultHighlightStyle();
-      clickStyleProps = defaultHighlightStyle.getLayerProps(this._layer);
+      const defaultHighlightStyle = await this._getDefaultHighlightStyle();
+      clickStyleProps = await defaultHighlightStyle.getLayerProps(this._layer);
     } else if (this._clickStyle instanceof Style) {
       clickStyleProps = this._clickStyle.getLayerProps(this._layer);
     }
@@ -187,8 +189,8 @@ export class LayerInteractivity {
     let hoverStyleProps = {};
 
     if (this._hoverStyle === 'default') {
-      const defaultHighlightStyle = this._getDefaultHighlightStyle();
-      hoverStyleProps = defaultHighlightStyle.getLayerProps(this._layer);
+      const defaultHighlightStyle = await this._getDefaultHighlightStyle();
+      hoverStyleProps = await defaultHighlightStyle.getLayerProps(this._layer);
     } else if (this._hoverStyle instanceof Style) {
       hoverStyleProps = this._hoverStyle.getLayerProps(this._layer);
     }
@@ -265,9 +267,9 @@ export class LayerInteractivity {
     }
   }
 
-  private _getDefaultHighlightStyle() {
+  private async _getDefaultHighlightStyle() {
     const defaultHighlightProps: StyleProperties = {};
-    const styleProps = this._layerGetStyleFn().getLayerProps(this._layer);
+    const styleProps = await (await this._layerGetStyleFn()).getLayerProps(this._layer);
 
     if (styleProps.getIcon) {
       // icons
@@ -307,7 +309,7 @@ export interface LayerInteractivityOptions {
   /**
    * getStyle method of the layer
    */
-  layerGetStyleFn: () => Style;
+  layerGetStyleFn: () => Promise<Style>;
 
   /**
    * setStyle method of the layer

--- a/src/viz/legend/LegendWidget.ts
+++ b/src/viz/legend/LegendWidget.ts
@@ -21,10 +21,14 @@ export class LegendWidget {
     const legendWidget = domElement as any;
 
     if (layer.isReady()) {
-      legendWidget.data = layer.getLegendData(options);
+      layer.getLegendData(options).then(legendData => {
+        legendWidget.data = legendData;
+      });
     } else {
       layer.on(LayerEvent.DATA_READY, () => {
-        legendWidget.data = layer.getLegendData(options);
+        layer.getLegendData(options).then(legendData => {
+          legendWidget.data = legendData;
+        });
       });
     }
   }

--- a/src/viz/source/__tests__/SQLSource.spec.ts
+++ b/src/viz/source/__tests__/SQLSource.spec.ts
@@ -1,6 +1,6 @@
 import { Credentials, defaultCredentials, setDefaultCredentials } from '@/auth';
 import { Client } from '@/maps/Client';
-import { SQLSource } from '../SQLSource';
+import { SQLSource } from '..';
 
 const TEST_CREDENTIALS = {
   username: 'test_username',

--- a/src/viz/style/deck-styles.ts
+++ b/src/viz/style/deck-styles.ts
@@ -79,6 +79,9 @@ export interface BasicOptionsStyle {
   strokeColor: string;
   // Size of the stroke
   strokeWidth: number;
+  // If true the style is applied only for the viewport features.
+  // Default is false.
+  viewport: boolean;
 }
 
 export function getStyles(geometryType?: GeometryType, options: Partial<BasicOptionsStyle> = {}) {

--- a/src/viz/style/helpers/size-bins-style.ts
+++ b/src/viz/style/helpers/size-bins-style.ts
@@ -1,4 +1,5 @@
 import { NumericFieldStats, GeometryType, SourceMetadata } from '@/viz/source';
+import { Layer } from '@/viz';
 import { LegendProperties, LegendGeometryType } from '@/viz/legend';
 import { findIndexForBinBuckets, calculateSizeBins } from './utils';
 import { Classifier, ClassificationMethod } from '../../utils/Classifier';
@@ -40,6 +41,7 @@ function defaultOptions(
     sizeRange: getStyleValue('sizeRange', geometryType, options),
     nullSize: 0,
     opacity: 0.7,
+    viewport: options.viewport || false,
     ...options
   };
 }
@@ -48,7 +50,7 @@ export function sizeBinsStyle(
   featureProperty: string,
   options: Partial<SizeBinsOptionsStyle> = {}
 ) {
-  const evalFN = (layer: StyledLayer) => {
+  const evalFN = async (layer: StyledLayer) => {
     const meta = layer.source.getMetadata();
 
     if (layer.source.isEmpty()) {
@@ -65,15 +67,12 @@ export function sizeBinsStyle(
       );
     }
 
-    return calculateWithBreaks(
-      featureProperty,
-      getBreaks(opts, meta, featureProperty),
-      meta.geometryType,
-      opts
-    );
+    const dataOrigin = opts.viewport ? (layer as Layer) : meta;
+    const breaks = await getBreaks(opts, dataOrigin, featureProperty);
+    return calculateWithBreaks(featureProperty, breaks, meta.geometryType, opts);
   };
 
-  const evalFNLegend = (layer: StyledLayer, properties = {}): LegendProperties[] => {
+  const evalFNLegend = async (layer: StyledLayer, properties = {}): Promise<LegendProperties[]> => {
     const meta = layer.source.getMetadata();
 
     if (!meta.geometryType) {
@@ -81,10 +80,11 @@ export function sizeBinsStyle(
     }
 
     const opts = defaultOptions(meta.geometryType, options);
-    const breaks = getBreaks(opts, meta, featureProperty);
+    const dataOrigin = opts.viewport ? (layer as Layer) : meta;
+    const breaks = await getBreaks(opts, dataOrigin, featureProperty);
     const stats = meta.stats.find(f => f.name === featureProperty) as NumericFieldStats;
     let ranges = [...breaks, stats.max];
-    const sizes = calculateSizeBins(breaks.length, opts.sizeRange);
+    const sizes = await calculateSizeBins(breaks.length, opts.sizeRange);
     const styles = getStyles(meta.geometryType, options) as any;
     ranges = [stats.min, ...ranges];
     const geometryType = meta.geometryType.toLocaleLowerCase() as LegendGeometryType;
@@ -102,21 +102,29 @@ export function sizeBinsStyle(
     });
   };
 
-  return new Style(evalFN, featureProperty, evalFNLegend);
+  return new Style(evalFN, featureProperty, evalFNLegend, options.viewport);
 }
 
-function getBreaks(opts: SizeBinsOptionsStyle, meta: SourceMetadata, featureProperty: string) {
+async function getBreaks(
+  opts: SizeBinsOptionsStyle,
+  dataOrigin: Layer | SourceMetadata,
+  featureProperty: string
+) {
   if (!opts.breaks.length) {
-    const stats = meta.stats.find(f => f.name === featureProperty) as NumericFieldStats;
-    const classifier = new Classifier(stats);
-    const breaks = classifier.breaks(opts.bins - 1, opts.method);
+    const data = (dataOrigin as SourceMetadata).stats
+      ? ((dataOrigin as SourceMetadata).stats.find(
+          f => f.name === featureProperty
+        ) as NumericFieldStats)
+      : (dataOrigin as Layer);
+    const classifier = new Classifier(data, featureProperty);
+    const breaks = await classifier.breaks(opts.bins - 1, opts.method, opts.viewport);
     return breaks;
   }
 
   return opts.breaks;
 }
 
-function calculateWithBreaks(
+async function calculateWithBreaks(
   featureProperty: string,
   breaks: number[],
   geometryType: GeometryType | undefined,
@@ -133,7 +141,7 @@ function calculateWithBreaks(
   const ranges = [...breaks, Number.MAX_SAFE_INTEGER];
 
   // calculate sizes based on breaks and sizeRanges.
-  const sizes = calculateSizeBins(breaks.length, options.sizeRange);
+  const sizes = await calculateSizeBins(breaks.length, options.sizeRange);
 
   /**
    * @private

--- a/src/viz/style/helpers/utils.ts
+++ b/src/viz/style/helpers/utils.ts
@@ -84,11 +84,15 @@ export function findIndexForBinBuckets(buckets: number[], featureValue: number) 
   return buckets.findIndex(rangeComparison);
 }
 
-export function calculateSizeBins(nBreaks: number, sizeRange: number[]) {
+export async function calculateSizeBins(nBreaks: number, sizeRange: number[]) {
   // calculate sizes based on breaks and sizeRanges. We used the equal classifier
   const classObj = {
     min: sizeRange[0],
     max: sizeRange[1]
   };
-  return [sizeRange[0], ...new Classifier(classObj).breaks(nBreaks - 1, 'equal'), sizeRange[1]];
+  return [
+    sizeRange[0],
+    ...(await new Classifier(classObj).breaks(nBreaks - 1, 'equal')),
+    sizeRange[1]
+  ];
 }

--- a/src/viz/utils/Classifier.ts
+++ b/src/viz/utils/Classifier.ts
@@ -1,111 +1,187 @@
 import { Stats } from '@/viz/source';
 import { CartoStylingError, stylingErrorTypes } from '../errors/styling-error';
+import { Layer } from '../layer';
 
 export type ClassificationMethod = 'quantiles' | 'stdev' | 'equal';
 
 export class Classifier {
-  private _stats: Stats;
+  private dataOrigin: Stats | Layer;
+  private featureProperty?: string;
 
-  constructor(stats: Stats) {
-    this._stats = stats;
+  constructor(dataOrigin: Stats | Layer, featureProperty?: string) {
+    this.dataOrigin = dataOrigin;
+    this.featureProperty = featureProperty;
   }
 
-  public breaks(nBreaks: number, method: ClassificationMethod): number[] {
+  public breaks(nBreaks: number, method: ClassificationMethod, viewport = false) {
+    validateParameters(this.dataOrigin, this.featureProperty, viewport, method);
+
     if (nBreaks === 0) {
       return [];
     }
 
     switch (method) {
       case 'quantiles':
-        return this._quantilesBreaks(nBreaks);
+        return this._quantilesBreaks(nBreaks, viewport);
       case 'equal':
-        return this._equalBreaks(nBreaks);
+        return this._equalBreaks(nBreaks, viewport);
       case 'stdev':
-        return this._standarDev(nBreaks);
+        return this._standarDev(nBreaks, undefined, viewport);
 
       default:
         throw new Error(`Unsupported classify method ${method}`);
     }
   }
 
-  private _quantilesBreaks(nBreaks: number): number[] {
-    if (!this._stats.sample) {
+  private async _quantilesBreaks(nBreaks: number, viewport = false): Promise<number[]> {
+    const data = await this.getData(viewport);
+
+    const breaks: number[] = [];
+
+    if (data.length > 0) {
+      const sortedSample = [...data].sort((x, y) => x - y);
+      const minNBreaks = Math.min(sortedSample.length, nBreaks);
+
+      for (let i = 1; i <= minNBreaks; i += 1) {
+        const p = i / (minNBreaks + 1);
+        const index = Math.max(0, Math.floor(p * sortedSample.length) - 1);
+        breaks.push(sortedSample[index]);
+      }
+    }
+
+    return breaks;
+  }
+
+  private async _equalBreaks(nBreaks: number, viewport = false): Promise<number[]> {
+    const { min, max } = await this.getMinMax(viewport);
+
+    const breaks: number[] = [];
+
+    if (min && max) {
+      for (let i = 1; i <= nBreaks; i += 1) {
+        const p = i / (nBreaks + 1);
+        breaks.push(min + (max - min) * p);
+      }
+    }
+
+    return breaks;
+  }
+
+  private async _standarDev(nBreaks: number, classSize = 1.0, viewport = false): Promise<number[]> {
+    const data = await this.getData(viewport);
+    const avg = await this.getAvg(viewport);
+    // const stdev = this.getStdev(viewport);
+
+    let breaks: number[] = [];
+
+    if (avg && data.length > 0) {
+      const stdev = standardDeviation(data, avg);
+
+      const over = [];
+      const under = [];
+      const isEven = (nBreaks + 1) % 2 === 0;
+      let factor = isEven ? 0.0 : 1.0; // if odd, central class is double sized
+
+      do {
+        const step = factor * (stdev * classSize);
+        over.push(avg + step);
+        under.push(avg - step);
+        breaks = [...new Set(over.concat(under))];
+        breaks.sort((a, b) => a - b);
+        factor += 1;
+      } while (breaks.length < nBreaks);
+    }
+
+    return breaks;
+  }
+
+  private async getData(viewport: boolean) {
+    let data: number[] = [];
+
+    const { featureProperty } = this;
+    const layer = this.dataOrigin as Layer;
+    const stats = this.dataOrigin as Stats;
+
+    if (viewport && featureProperty) {
+      try {
+        const features = await layer.getViewportFeatures();
+        data = features.filter(f => !!f[featureProperty]).map(f => f[featureProperty] as number);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(err);
+      }
+    } else if (stats.sample) {
+      data = stats.sample;
+    }
+
+    return data;
+  }
+
+  private async getMinMax(viewport: boolean) {
+    let min;
+    let max;
+
+    const stats = this.dataOrigin as Stats;
+
+    if (viewport) {
+      const data = await this.getData(viewport);
+
+      if (data.length > 0) {
+        min = Math.min(...data);
+        max = Math.max(...data);
+      }
+    } else if (stats.sample) {
+      min = stats.min;
+      max = stats.max;
+    }
+
+    return { min, max };
+  }
+
+  private async getAvg(viewport: boolean) {
+    let avg;
+
+    const stats = this.dataOrigin as Stats;
+
+    if (viewport) {
+      const data = await this.getData(viewport);
+
+      if (data.length > 0) {
+        avg = data.reduce((a, b) => a + b) / data.length;
+      }
+    } else {
+      avg = stats.avg;
+    }
+
+    return avg;
+  }
+}
+
+function validateParameters(
+  dataOrigin: Stats | Layer,
+  featureProperty: string | undefined,
+  viewport: boolean,
+  method: ClassificationMethod
+) {
+  if (viewport && !featureProperty) {
+    throw new CartoStylingError(
+      'The feature property should be provided when viewport is used',
+      stylingErrorTypes.PROPERTY_MISSING
+    );
+  }
+
+  if (method === 'quantiles') {
+    if (viewport && !(dataOrigin instanceof Layer)) {
+      throw new CartoStylingError(
+        'You have to provide a Layer in order to calculate breaks for viewport features',
+        stylingErrorTypes.PROPERTY_MISMATCH
+      );
+    } else if (!viewport && !(dataOrigin as Stats).sample) {
       throw new CartoStylingError(
         'Quantile method requires a sample in stats',
         stylingErrorTypes.CLASS_METHOD_UNSUPPORTED
       );
     }
-
-    const sortedSample = [...this._stats.sample].sort((x, y) => x - y);
-
-    const breaks: number[] = [];
-
-    for (let i = 1; i <= nBreaks; i += 1) {
-      const p = i / (nBreaks + 1);
-      breaks.push(sortedSample[Math.floor(p * sortedSample.length) - 1]);
-    }
-
-    return breaks;
-  }
-
-  private _equalBreaks(nBreaks: number): number[] {
-    const { min, max } = this._stats;
-
-    if (min === undefined || max === undefined) {
-      throw new CartoStylingError(
-        'Equal breaks requires max and min in stats',
-        stylingErrorTypes.CLASS_METHOD_UNSUPPORTED
-      );
-    }
-
-    const breaks: number[] = [];
-
-    for (let i = 1; i <= nBreaks; i += 1) {
-      const p = i / (nBreaks + 1);
-      breaks.push(min + (max - min) * p);
-    }
-
-    return breaks;
-  }
-
-  private _standarDev(nBreaks: number, classSize = 1.0): number[] {
-    const { avg, sample } = this._stats;
-    let { stdev } = this._stats;
-
-    if (avg === undefined) {
-      throw new CartoStylingError(
-        'Standard dev requires avg in stats',
-        stylingErrorTypes.CLASS_METHOD_UNSUPPORTED
-      );
-    }
-
-    if (stdev === undefined) {
-      if (!sample) {
-        throw new CartoStylingError(
-          'Standard dev requires samples in stats',
-          stylingErrorTypes.CLASS_METHOD_UNSUPPORTED
-        );
-      }
-
-      stdev = standardDeviation(sample, avg);
-    }
-
-    let breaks;
-    const over = [];
-    const under = [];
-    const isEven = (nBreaks + 1) % 2 === 0;
-    let factor = isEven ? 0.0 : 1.0; // if odd, central class is double sized
-
-    do {
-      const step = factor * (stdev * classSize);
-      over.push(avg + step);
-      under.push(avg - step);
-      breaks = [...new Set(over.concat(under))];
-      breaks.sort((a, b) => a - b);
-      factor += 1;
-    } while (breaks.length < nBreaks);
-
-    return breaks;
   }
 }
 


### PR DESCRIPTION
Added the new option `viewport` to style helpers for setting styles when the viewport changes. Example for size bins:

```javascript
const style = carto.viz.style.sizeBins('sale_price', {
  viewport: true
});
const layer = new carto.viz.Layer('clev_sales', style);
```