### PR TITLE
Refactor layer class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Add new `Legend` widget for layers, working for these styles: basic, colorBins, colorCategories, colorContinuous, sizeBins, sizeCategories and sizeContinuous (#100, #102, #104, #105, #106, #107, #109 and #113)
 - New `getId` method in `carto.viz.Layer` ([#113](https://github.com/CartoDB/web-sdk/pull/113/))
 
+### Changed
+
+- Rename several public members in `carto.viz.Layer`: methods `replaceDeckGLLayer`, `getDeckGLLayer`, `getMapInstance` and property `source` to `replaceDeckLayer`, `getDeckLayer`, `getMap` and `getSource` ([#124](https://github.com/CartoDB/web-sdk/pull/124/))
+
 ### Fixed
 
 - Fix WEBSDK VERSION for .cjs & .esm module distributions ([#115](https://github.com/CartoDB/web-sdk/pull/115/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - Add new `Legend` widget for layers, working for these styles: basic, colorBins, colorCategories, colorContinuous, sizeBins, sizeCategories and sizeContinuous (#100, #102, #104, #105, #106, #107, #109 and #113)
+- New `viewport` mode for style classifiers: quantiles, equal and stdev ([#119](https://github.com/CartoDB/web-sdk/pull/119/))
 - New `getId` method in `carto.viz.Layer` ([#113](https://github.com/CartoDB/web-sdk/pull/113/))
 
 ### Changed
@@ -17,6 +18,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Fix WEBSDK VERSION for .cjs & .esm module distributions ([#115](https://github.com/CartoDB/web-sdk/pull/115/))
+- Fix error on viewport mode in classifiers, with first render without proper styles ([#124](https://github.com/CartoDB/web-sdk/pull/124/))
+- Fix `remove` error in `carto.viz.Layer`, keeping the reference to the old map ([#124](https://github.com/CartoDB/web-sdk/pull/124/))
 
 ## [1.0.0-alpha.2] 2020-07-31
 

--- a/src/core/utils/events.ts
+++ b/src/core/utils/events.ts
@@ -1,0 +1,49 @@
+import { WithEvents } from '@/core/mixins/WithEvents';
+
+/**
+ * Returns a promise which will be resolved once the event is triggered on emitter,
+ * so you can "wait for the event" to happen.
+ *
+ * This is a simple way to transform an event handler into a promise.
+ * This ain't have a timeout, so beware of locks
+ *
+ * @param {WithEvents} emitter
+ * @param {string} eventType
+ * @returns {Promise<any>}
+ */
+export function waitForEvent(emitter: WithEvents, eventType: string): Promise<any> {
+  return new Promise(function (resolve) {
+    emitter.on(eventType, resolve);
+  });
+}
+
+// waitForEventWithTimeout
+
+/**
+ * Returns a promise which will be resolved once the event is triggered on emitter,
+ * so you can "wait for the event" to happen. It imposes also a timeout. If that is
+ * consumed without the event happening, an error is returned
+ *
+ * @export
+ * @param {WithEvents} emitter
+ * @param {string} eventType
+ * @param {number} [timeOut=10000] 10s by default
+ * @returns {Promise<any>}
+ */
+export function waitForEventWithTimeout(
+  emitter: WithEvents,
+  eventType: string,
+  timeOut = 10000
+): Promise<any> {
+  const timeoutPromise = new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(
+        new Error(
+          `Timeout at waitForEventWithTimeout: ${eventType} did not happen on ${emitter} in ${timeOut} milliseconds`
+        )
+      );
+    }, timeOut);
+  });
+
+  return Promise.race([timeoutPromise, waitForEvent(emitter, eventType)]);
+}

--- a/src/viz/__tests__/Layer.spec.ts
+++ b/src/viz/__tests__/Layer.spec.ts
@@ -70,7 +70,7 @@ describe('Layer', () => {
         const layer = new Layer(DEFAULT_DATASET);
         await layer.addTo(deckInstanceMock);
 
-        const deckGLLayer = await layer.getDeckGLLayer();
+        const deckGLLayer = await layer.getDeckLayer();
         expect(deckInstanceMock.setProps).toHaveBeenCalledWith(
           expect.objectContaining({
             layers: expect.arrayContaining([deckGLLayer])
@@ -85,7 +85,7 @@ describe('Layer', () => {
         const layer2 = new Layer(DEFAULT_DATASET, {}, { id: 'layer2' });
         await layer2.addTo(deckInstanceMock);
 
-        await layer1.replaceDeckGLLayer();
+        await layer1.replaceDeckLayer();
         expect(deckInstanceMock.props.layers.length).toBe(2);
         expect(deckInstanceMock.props.layers[0].id).toBe('layer1');
         expect(deckInstanceMock.props.layers[1].id).toBe('layer2');
@@ -98,7 +98,7 @@ describe('Layer', () => {
         const layer2 = new Layer(DEFAULT_DATASET, {}, { id: 'layer2' });
         await layer2.addTo(deckInstanceMock, { overLayerId: 'layer1' });
 
-        await layer1.replaceDeckGLLayer();
+        await layer1.replaceDeckLayer();
         expect(deckInstanceMock.props.layers.length).toBe(2);
         expect(deckInstanceMock.props.layers[0].id).toBe('layer1');
         expect(deckInstanceMock.props.layers[1].id).toBe('layer2');
@@ -114,7 +114,7 @@ describe('Layer', () => {
         const layer3 = new Layer(DEFAULT_DATASET, {}, { id: 'layer3' });
         await layer3.addTo(deckInstanceMock, { underLayerId: 'layer2' });
 
-        await layer1.replaceDeckGLLayer();
+        await layer1.replaceDeckLayer();
         expect(deckInstanceMock.props.layers.length).toBe(3);
         expect(deckInstanceMock.props.layers[0].id).toBe('layer1');
         expect(deckInstanceMock.props.layers[1].id).toBe('layer3');
@@ -123,7 +123,7 @@ describe('Layer', () => {
     });
   });
 
-  describe('.getDeckGLLayer', () => {
+  describe('.getDeckLayer', () => {
     const data = [
       'https://a.cartocdn.net/username/api/v1/map/map_id/layer0/{z}/{x}/{y}.mvt?api_key=default_public',
       'https://b.cartocdn.net/username/api/v1/map/map_id/layer0/{z}/{x}/{y}.mvt?api_key=default_public',
@@ -137,7 +137,7 @@ describe('Layer', () => {
       };
 
       const layer = new Layer(DEFAULT_DATASET);
-      const deckGLLayer = await layer.getDeckGLLayer();
+      const deckGLLayer = await layer.getDeckLayer();
       expect(deckGLLayer.props).toMatchObject(defaultProperties);
     });
 
@@ -152,7 +152,7 @@ describe('Layer', () => {
         getFillColor: [128, 128, 128]
       });
 
-      const deckGLLayer = await layer.getDeckGLLayer();
+      const deckGLLayer = await layer.getDeckLayer();
       expect(deckGLLayer.props).toMatchObject(layerProperties);
     });
   });

--- a/src/viz/__tests__/Legend.spec.ts
+++ b/src/viz/__tests__/Legend.spec.ts
@@ -234,8 +234,8 @@ describe('Legend', () => {
         const colorBins = colorBinsStyle(POINT_NUMERIC_FIELD);
         await pointLayer.setStyle(colorBins);
         const colorBinsStyleProps = await colorBins.getLayerProps(pointLayer);
-        const maxVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).max;
-        const minVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).min;
+        const maxVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).max;
+        const minVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).min;
         const maxColor = (colorBinsStyleProps.getFillColor as (d: any) => RGBAColor)({
           properties: { [POINT_NUMERIC_FIELD]: maxVal }
         });
@@ -266,8 +266,8 @@ describe('Legend', () => {
         const colorBins = colorBinsStyle(POINT_NUMERIC_FIELD);
         await pointLayer.setStyle(colorBins);
         const colorBinsStyleProps = await colorBins.getLayerProps(pointLayer);
-        const maxVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).max;
-        const minVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).min;
+        const maxVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).max;
+        const minVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).min;
         const maxColor = (colorBinsStyleProps.getFillColor as (d: any) => RGBAColor)({
           properties: { [POINT_NUMERIC_FIELD]: maxVal }
         });
@@ -368,11 +368,11 @@ describe('Legend', () => {
         const colorContinuous = colorContinuousStyle(POLYGON_NUMERIC_FIELD);
         await polygonLayer.setStyle(colorContinuous);
         const colorContinuousStyleProps = await colorContinuous.getLayerProps(polygonLayer);
-        const maxVal = (polygonLayer.source.getMetadata().stats[0] as NumericFieldStats).max;
+        const maxVal = (polygonLayer.getSource().getMetadata().stats[0] as NumericFieldStats).max;
         const maxColor = (colorContinuousStyleProps.getFillColor as (d: any) => RGBAColor)({
           properties: { [POLYGON_NUMERIC_FIELD]: maxVal }
         });
-        const minVal = (polygonLayer.source.getMetadata().stats[0] as NumericFieldStats).min;
+        const minVal = (polygonLayer.getSource().getMetadata().stats[0] as NumericFieldStats).min;
         const minColor = (colorContinuousStyleProps.getFillColor as (d: any) => RGBAColor)({
           properties: { [POLYGON_NUMERIC_FIELD]: minVal }
         });
@@ -400,11 +400,11 @@ describe('Legend', () => {
         const colorContinuous = colorContinuousStyle(POLYGON_NUMERIC_FIELD);
         await polygonLayer.setStyle(colorContinuous);
         const colorContinuousStyleProps = await colorContinuous.getLayerProps(polygonLayer);
-        const minVal = (polygonLayer.source.getMetadata().stats[0] as NumericFieldStats).min;
+        const minVal = (polygonLayer.getSource().getMetadata().stats[0] as NumericFieldStats).min;
         const minColor = (colorContinuousStyleProps.getFillColor as (d: any) => RGBAColor)({
           properties: { [POLYGON_NUMERIC_FIELD]: minVal }
         });
-        const maxVal = (polygonLayer.source.getMetadata().stats[0] as NumericFieldStats).max;
+        const maxVal = (polygonLayer.getSource().getMetadata().stats[0] as NumericFieldStats).max;
         const maxColor = (colorContinuousStyleProps.getFillColor as (d: any) => RGBAColor)({
           properties: { [POLYGON_NUMERIC_FIELD]: maxVal }
         });
@@ -441,11 +441,11 @@ describe('Legend', () => {
         const sizeBins = sizeBinsStyle(POINT_NUMERIC_FIELD);
         await pointLayer.setStyle(sizeBins);
         const sizeBinsStyleProps = await sizeBins.getLayerProps(pointLayer);
-        const maxVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).max;
+        const maxVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).max;
         const maxRadius = (sizeBinsStyleProps.getRadius as (d: any) => number)({
           properties: { [POINT_NUMERIC_FIELD]: maxVal }
         });
-        const minVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).min;
+        const minVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).min;
         const minRadius = (sizeBinsStyleProps.getRadius as (d: any) => number)({
           properties: { [POINT_NUMERIC_FIELD]: minVal }
         });
@@ -470,11 +470,11 @@ describe('Legend', () => {
         const sizeBins = sizeBinsStyle(POINT_NUMERIC_FIELD);
         await pointLayer.setStyle(sizeBins);
         const sizeBinsStyleProps = await sizeBins.getLayerProps(pointLayer);
-        const minVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).min;
+        const minVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).min;
         const minRadius = (sizeBinsStyleProps.getRadius as (d: any) => number)({
           properties: { [POINT_NUMERIC_FIELD]: minVal }
         });
-        const maxVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).max;
+        const maxVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).max;
         const maxRadius = (sizeBinsStyleProps.getRadius as (d: any) => number)({
           properties: { [POINT_NUMERIC_FIELD]: maxVal }
         });
@@ -573,11 +573,11 @@ describe('Legend', () => {
         const sizeContinuous = sizeContinuousStyle(POINT_NUMERIC_FIELD);
         await pointLayer.setStyle(sizeContinuous);
         const sizeContinuousStyleProps = await sizeContinuous.getLayerProps(pointLayer);
-        const maxVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).max;
+        const maxVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).max;
         const maxRadius = (sizeContinuousStyleProps.getRadius as (d: any) => number)({
           properties: { [POINT_NUMERIC_FIELD]: maxVal }
         });
-        const minVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).min;
+        const minVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).min;
         const minRadius = (sizeContinuousStyleProps.getRadius as (d: any) => number)({
           properties: { [POINT_NUMERIC_FIELD]: minVal }
         });
@@ -606,11 +606,11 @@ describe('Legend', () => {
         const sizeContinuous = sizeContinuousStyle(POINT_NUMERIC_FIELD);
         await pointLayer.setStyle(sizeContinuous);
         const sizeContinuousStyleProps = await sizeContinuous.getLayerProps(pointLayer);
-        const minVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).min;
+        const minVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).min;
         const minRadius = (sizeContinuousStyleProps.getRadius as (d: any) => number)({
           properties: { [POINT_NUMERIC_FIELD]: minVal }
         });
-        const maxVal = (pointLayer.source.getMetadata().stats[0] as NumericFieldStats).max;
+        const maxVal = (pointLayer.getSource().getMetadata().stats[0] as NumericFieldStats).max;
         const maxRadius = (sizeContinuousStyleProps.getRadius as (d: any) => number)({
           properties: { [POINT_NUMERIC_FIELD]: maxVal }
         });

--- a/src/viz/__tests__/styles/BasicStyle.spec.ts
+++ b/src/viz/__tests__/styles/BasicStyle.spec.ts
@@ -18,7 +18,7 @@ jest.mock('../../source/DatasetSource', () => ({
 
 const styledLayer = {
   getId: () => uuidv4(),
-  getMapInstance: () => ({} as Deck),
+  getMap: () => ({} as Deck),
   source: new DatasetSource('table')
 };
 

--- a/src/viz/__tests__/styles/BasicStyle.spec.ts
+++ b/src/viz/__tests__/styles/BasicStyle.spec.ts
@@ -19,7 +19,7 @@ jest.mock('../../source/DatasetSource', () => ({
 const styledLayer = {
   getId: () => uuidv4(),
   getMap: () => ({} as Deck),
-  source: new DatasetSource('table')
+  getSource: () => new DatasetSource('table')
 };
 
 describe('BasicStyle', () => {

--- a/src/viz/__tests__/styles/ColorBinsStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorBinsStyle.spec.ts
@@ -30,7 +30,7 @@ jest.mock('../../source/DatasetSource', () => ({
 const styledLayer = {
   getId: () => uuidv4(),
   getMap: () => ({} as Deck),
-  source: new DatasetSource('table')
+  getSource: () => new DatasetSource('table')
 };
 
 describe('ColorBinsStyle', () => {
@@ -148,7 +148,7 @@ describe('ColorBinsStyle', () => {
         property: 'strokeColor'
       });
       const styleLayerPoint = { ...styledLayer };
-      styleLayerPoint.source.getMetadata = jest.fn().mockImplementation(() => {
+      styleLayerPoint.getSource().getMetadata = jest.fn().mockImplementation(() => {
         return {
           geometryType: 'Point',
           stats: [stats]

--- a/src/viz/__tests__/styles/ColorBinsStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorBinsStyle.spec.ts
@@ -29,7 +29,7 @@ jest.mock('../../source/DatasetSource', () => ({
 
 const styledLayer = {
   getId: () => uuidv4(),
-  getMapInstance: () => ({} as Deck),
+  getMap: () => ({} as Deck),
   source: new DatasetSource('table')
 };
 

--- a/src/viz/__tests__/styles/ColorCategoriesStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorCategoriesStyle.spec.ts
@@ -31,7 +31,7 @@ jest.mock('../../source/DatasetSource', () => ({
 const styledLayer = {
   getId: () => uuidv4(),
   getMap: () => ({} as Deck),
-  source: new DatasetSource('table')
+  getSource: () => new DatasetSource('table')
 };
 
 describe('ColorCategoriesStyle', () => {
@@ -135,7 +135,7 @@ describe('ColorCategoriesStyle', () => {
         property: 'strokeColor'
       });
       const styleLayerPoint = { ...styledLayer };
-      styleLayerPoint.source.getMetadata = jest.fn().mockImplementation(() => {
+      styleLayerPoint.getSource().getMetadata = jest.fn().mockImplementation(() => {
         return {
           geometryType: 'Polygon',
           stats: [

--- a/src/viz/__tests__/styles/ColorCategoriesStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorCategoriesStyle.spec.ts
@@ -30,7 +30,7 @@ jest.mock('../../source/DatasetSource', () => ({
 
 const styledLayer = {
   getId: () => uuidv4(),
-  getMapInstance: () => ({} as Deck),
+  getMap: () => ({} as Deck),
   source: new DatasetSource('table')
 };
 

--- a/src/viz/__tests__/styles/ColorContinuousStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorContinuousStyle.spec.ts
@@ -30,7 +30,7 @@ jest.mock('../../source/DatasetSource', () => ({
 const styledLayer = {
   getId: () => uuidv4(),
   getMap: () => ({} as Deck),
-  source: new DatasetSource('table')
+  getSource: () => new DatasetSource('table')
 };
 
 describe('ColorContinuousStyle', () => {
@@ -99,7 +99,7 @@ describe('ColorContinuousStyle', () => {
         property: 'strokeColor'
       });
       const styleLayerPoint = { ...styledLayer };
-      styleLayerPoint.source.getMetadata = jest.fn().mockImplementation(() => {
+      styleLayerPoint.getSource().getMetadata = jest.fn().mockImplementation(() => {
         return {
           geometryType: 'Point',
           stats: [stats]

--- a/src/viz/__tests__/styles/ColorContinuousStyle.spec.ts
+++ b/src/viz/__tests__/styles/ColorContinuousStyle.spec.ts
@@ -29,7 +29,7 @@ jest.mock('../../source/DatasetSource', () => ({
 
 const styledLayer = {
   getId: () => uuidv4(),
-  getMapInstance: () => ({} as Deck),
+  getMap: () => ({} as Deck),
   source: new DatasetSource('table')
 };
 

--- a/src/viz/__tests__/styles/SizeBinsStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeBinsStyle.spec.ts
@@ -30,7 +30,7 @@ jest.mock('../../source/DatasetSource', () => ({
 const styledLayer = {
   getId: () => uuidv4(),
   getMap: () => ({} as Deck),
-  source: new DatasetSource('table')
+  getSource: () => new DatasetSource('table')
 };
 
 describe('SizeBinsStyle', () => {

--- a/src/viz/__tests__/styles/SizeBinsStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeBinsStyle.spec.ts
@@ -29,7 +29,7 @@ jest.mock('../../source/DatasetSource', () => ({
 
 const styledLayer = {
   getId: () => uuidv4(),
-  getMapInstance: () => ({} as Deck),
+  getMap: () => ({} as Deck),
   source: new DatasetSource('table')
 };
 

--- a/src/viz/__tests__/styles/SizeCategoriesStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeCategoriesStyle.spec.ts
@@ -30,7 +30,7 @@ jest.mock('../../source/DatasetSource', () => ({
 const styledLayer = {
   getId: () => uuidv4(),
   getMap: () => ({} as Deck),
-  source: new DatasetSource('table')
+  getSource: () => new DatasetSource('table')
 };
 
 describe('SizeCategoriesStyle', () => {

--- a/src/viz/__tests__/styles/SizeCategoriesStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeCategoriesStyle.spec.ts
@@ -29,7 +29,7 @@ jest.mock('../../source/DatasetSource', () => ({
 
 const styledLayer = {
   getId: () => uuidv4(),
-  getMapInstance: () => ({} as Deck),
+  getMap: () => ({} as Deck),
   source: new DatasetSource('table')
 };
 

--- a/src/viz/__tests__/styles/SizeContinuousStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeContinuousStyle.spec.ts
@@ -29,7 +29,7 @@ jest.mock('../../source/DatasetSource', () => ({
 const styledLayer = {
   getId: () => uuidv4(),
   getMap: () => ({} as Deck),
-  source: new DatasetSource('table')
+  getSource: () => new DatasetSource('table')
 };
 
 describe('SizeContinuousStyle', () => {

--- a/src/viz/__tests__/styles/SizeContinuousStyle.spec.ts
+++ b/src/viz/__tests__/styles/SizeContinuousStyle.spec.ts
@@ -28,7 +28,7 @@ jest.mock('../../source/DatasetSource', () => ({
 
 const styledLayer = {
   getId: () => uuidv4(),
-  getMapInstance: () => ({} as Deck),
+  getMap: () => ({} as Deck),
   source: new DatasetSource('table')
 };
 

--- a/src/viz/dataview/DataView.ts
+++ b/src/viz/dataview/DataView.ts
@@ -155,7 +155,7 @@ export function getCredentialsFrom(dataOrigin: Layer | Source): Credentials | un
   let source = dataOrigin;
 
   if (source instanceof Layer) {
-    source = source.source;
+    source = source.getSource();
   }
 
   let credentials;

--- a/src/viz/dataview/mode/DataViewRemote.ts
+++ b/src/viz/dataview/mode/DataViewRemote.ts
@@ -76,6 +76,9 @@ export class DataViewRemote extends DataViewMode {
 
     this.dataOrigin.on(LayerEvent.TILES_LOADED, () => {
       const deckInstance = (this.dataOrigin as Layer).getMap();
+      if (deckInstance === undefined) {
+        throw new CartoDataViewError("Layer doesn't have a map innstance");
+      }
       const viewport = deckInstance.getViewports(undefined)[0];
 
       if (viewport) {
@@ -103,5 +106,5 @@ function getRemoteSource(dataOrigin: Layer | Source) {
   }
 
   const layer = dataOrigin as Layer;
-  return layer.source as SQLSource | DatasetSource;
+  return layer.getSource() as SQLSource | DatasetSource;
 }

--- a/src/viz/dataview/mode/DataViewRemote.ts
+++ b/src/viz/dataview/mode/DataViewRemote.ts
@@ -76,9 +76,11 @@ export class DataViewRemote extends DataViewMode {
 
     this.dataOrigin.on(LayerEvent.TILES_LOADED, () => {
       const deckInstance = (this.dataOrigin as Layer).getMap();
+
       if (deckInstance === undefined) {
         throw new CartoDataViewError("Layer doesn't have a map innstance");
       }
+
       const viewport = deckInstance.getViewports(undefined)[0];
 
       if (viewport) {

--- a/src/viz/dataview/mode/DataViewRemote.ts
+++ b/src/viz/dataview/mode/DataViewRemote.ts
@@ -75,7 +75,7 @@ export class DataViewRemote extends DataViewMode {
     }
 
     this.dataOrigin.on(LayerEvent.TILES_LOADED, () => {
-      const deckInstance = (this.dataOrigin as Layer).getMapInstance();
+      const deckInstance = (this.dataOrigin as Layer).getMap();
       const viewport = deckInstance.getViewports(undefined)[0];
 
       if (viewport) {

--- a/src/viz/dataview/utils.ts
+++ b/src/viz/dataview/utils.ts
@@ -28,7 +28,7 @@ export function debounce(
 
 export function isGeoJSONSource(dataOrigin: Layer | Source) {
   return (
-    (dataOrigin instanceof Layer && dataOrigin.source instanceof GeoJSONSource) ||
+    (dataOrigin instanceof Layer && dataOrigin.getSource() instanceof GeoJSONSource) ||
     dataOrigin instanceof GeoJSONSource
   );
 }

--- a/src/viz/layer/Layer.ts
+++ b/src/viz/layer/Layer.ts
@@ -104,7 +104,7 @@ export class Layer extends WithEvents implements StyledLayer {
   /**
    * Get the Deck `map` instance where the layer is included
    */
-  public getMapInstance(): Deck {
+  public getMap(): Deck {
     if (this._deckInstance === undefined) {
       throw new CartoLayerError(
         'Cannot return map instance because the layer has not been added to a map yet',

--- a/src/viz/layer/Layer.ts
+++ b/src/viz/layer/Layer.ts
@@ -102,31 +102,20 @@ export class Layer extends WithEvents implements StyledLayer {
   }
 
   /**
-   * Get the Deck `map` instance where the layer is included
+   * Get the Deck `map` instance where the layer was included or undefined if it wasn't
    */
-  public getMap(): Deck {
-    if (this._deckInstance === undefined) {
-      throw new CartoLayerError(
-        'Cannot return map instance because the layer has not been added to a map yet',
-        layerErrorTypes.DECK_MAP_NOT_FOUND
-      );
-    }
-
+  public getMap(): Deck | undefined {
     return this._deckInstance;
   }
 
-  // /**
-  //  * Get the data Source assigned to the layer
-  //  *
-  //  * @readonly
-  //  * @type {Source}
-  //  * @memberof Layer
-  //  */
-  // public getSource(): Source {
-  //   return this._source;
-  // }
-
-  public get source() {
+  /**
+   * Get the data Source assigned to the layer
+   *
+   * @readonly
+   * @type {Source}
+   * @memberof Layer
+   */
+  public getSource(): Source {
     return this._source;
   }
 

--- a/src/viz/layer/Layer.ts
+++ b/src/viz/layer/Layer.ts
@@ -257,6 +257,8 @@ export class Layer extends WithEvents implements StyledLayer {
     this._deckInstance.setProps({
       layers: deckLayers
     });
+
+    this._deckInstance = undefined;
   }
 
   /**

--- a/src/viz/style/helpers/basic-style.ts
+++ b/src/viz/style/helpers/basic-style.ts
@@ -5,7 +5,7 @@ import { Style, getStyles, BasicOptionsStyle } from '..';
 
 export function basicStyle(options: Partial<BasicOptionsStyle> = {}) {
   const evalFN = async (layer: StyledLayer) => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
     return getStyles(meta.geometryType, options);
   };
 
@@ -16,7 +16,7 @@ export function basicStyle(options: Partial<BasicOptionsStyle> = {}) {
     // TODO getMetadata throws an exception if source is empty. It could happen
     // if the user calls getLegendData layer method before ready event has been sent
 
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
     if (!meta.geometryType) {
       return [];

--- a/src/viz/style/helpers/color-bins-style.ts
+++ b/src/viz/style/helpers/color-bins-style.ts
@@ -55,9 +55,9 @@ export function colorBinsStyle(
   options: Partial<ColorBinsOptionsStyle> = {}
 ) {
   const evalFN = async (layer: StyledLayer) => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
-    if (layer.source.isEmpty()) {
+    if (layer.getSource().isEmpty()) {
       return {};
     }
 
@@ -74,7 +74,7 @@ export function colorBinsStyle(
     layer: StyledLayer,
     legendWidgetOptions: LegendWidgetOptions = { config: {} }
   ): Promise<LegendProperties[]> => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
     if (!meta.geometryType) {
       return [];

--- a/src/viz/style/helpers/color-categories-style.ts
+++ b/src/viz/style/helpers/color-categories-style.ts
@@ -46,9 +46,9 @@ export function colorCategoriesStyle(
   options: Partial<ColorCategoriesOptionsStyle> = {}
 ) {
   const evalFN = async (layer: StyledLayer) => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
-    if (layer.source.isEmpty()) {
+    if (layer.getSource().isEmpty()) {
       return {};
     }
 
@@ -66,7 +66,7 @@ export function colorCategoriesStyle(
     layer: StyledLayer,
     legendWidgetOptions: LegendWidgetOptions = {}
   ): Promise<LegendProperties[]> => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
     if (!meta.geometryType) {
       return [];

--- a/src/viz/style/helpers/color-continuous-style.ts
+++ b/src/viz/style/helpers/color-continuous-style.ts
@@ -43,9 +43,9 @@ export function colorContinuousStyle(
   options: Partial<ColorContinuousOptionsStyle> = {}
 ) {
   const evalFN = async (layer: StyledLayer) => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
-    if (layer.source.isEmpty()) {
+    if (layer.getSource().isEmpty()) {
       return {};
     }
 
@@ -82,7 +82,7 @@ export function colorContinuousStyle(
     layer: StyledLayer,
     legendWidgetOptions: LegendWidgetOptions = {}
   ): Promise<LegendProperties[]> => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
     if (!meta.geometryType) {
       return [];

--- a/src/viz/style/helpers/icon-style.ts
+++ b/src/viz/style/helpers/icon-style.ts
@@ -55,9 +55,9 @@ function defaultOptions(options: Partial<IconOptionsStyle>) {
 
 export function iconStyle(icon: string, options: Partial<IconOptionsStyle> = {}) {
   const evalFN = async (layer: StyledLayer) => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
-    if (layer.source.isEmpty()) {
+    if (layer.getSource().isEmpty()) {
       return {};
     }
 

--- a/src/viz/style/helpers/size-bins-style.ts
+++ b/src/viz/style/helpers/size-bins-style.ts
@@ -51,9 +51,9 @@ export function sizeBinsStyle(
   options: Partial<SizeBinsOptionsStyle> = {}
 ) {
   const evalFN = async (layer: StyledLayer) => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
-    if (layer.source.isEmpty()) {
+    if (layer.getSource().isEmpty()) {
       return {};
     }
 
@@ -76,7 +76,7 @@ export function sizeBinsStyle(
     layer: StyledLayer,
     legendWidgetOptions: LegendWidgetOptions = { config: {} }
   ): Promise<LegendProperties[]> => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
     if (!meta.geometryType) {
       return [];

--- a/src/viz/style/helpers/size-categories-style.ts
+++ b/src/viz/style/helpers/size-categories-style.ts
@@ -50,9 +50,9 @@ export function sizeCategoriesStyle(
   options: Partial<SizeCategoriesOptionsStyle> = {}
 ) {
   const evalFN = async (layer: StyledLayer) => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
-    if (layer.source.isEmpty()) {
+    if (layer.getSource().isEmpty()) {
       return {};
     }
 
@@ -69,7 +69,7 @@ export function sizeCategoriesStyle(
     layer: StyledLayer,
     legendWidgetOptions: LegendWidgetOptions = { config: {} }
   ): Promise<LegendProperties[]> => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
     if (!meta.geometryType) {
       return [];

--- a/src/viz/style/helpers/size-continuous-style.ts
+++ b/src/viz/style/helpers/size-continuous-style.ts
@@ -40,9 +40,9 @@ export function sizeContinuousStyle(
   options: Partial<SizeContinuousOptionsStyle> = {}
 ) {
   const evalFN = async (layer: StyledLayer) => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
-    if (layer.source.isEmpty()) {
+    if (layer.getSource().isEmpty()) {
       return {};
     }
 
@@ -79,7 +79,7 @@ export function sizeContinuousStyle(
     layer: StyledLayer,
     legendWidgetOptions: LegendWidgetOptions = { config: {} }
   ): Promise<LegendProperties[]> => {
-    const meta = layer.source.getMetadata();
+    const meta = layer.getSource().getMetadata();
 
     if (!meta.geometryType) {
       return [];

--- a/src/viz/style/layer-style.ts
+++ b/src/viz/style/layer-style.ts
@@ -3,6 +3,7 @@ import { Source } from '@/viz';
 
 export interface StyledLayer {
   getId(): string;
-  getMapInstance(): Deck;
+  getMap(): Deck;
   source: Source;
+  // getSource(): Source;
 }

--- a/src/viz/style/layer-style.ts
+++ b/src/viz/style/layer-style.ts
@@ -3,7 +3,6 @@ import { Source } from '@/viz';
 
 export interface StyledLayer {
   getId(): string;
-  getMap(): Deck;
-  source: Source;
-  // getSource(): Source;
+  getMap(): Deck | undefined;
+  getSource(): Source;
 }

--- a/src/viz/utils/Classifier.ts
+++ b/src/viz/utils/Classifier.ts
@@ -241,10 +241,6 @@ function average(values: number[]): number {
 }
 
 async function getDataFromViewport(layer: Layer, featureProperty: string): Promise<number[]> {
-  // if (!layer.isReady()) {
-  //   await waitForEventWithTimeout(layer, LayerEvent.DATA_READY);
-  // }
-
   const features = await layer.getViewportFeatures();
   const data = features.filter(f => !!f[featureProperty]).map(f => f[featureProperty] as number);
   return data;


### PR DESCRIPTION
Refactor
- A bit more of order into Layer class structure
- Some public methods rename (see changelog)

Fixes
+ Small fix on `Layer.remove`, to remove the map reference
+ Fix error on viewport mode in classifiers, with first render without proper styles