### PR TITLE
Fix: set deckInstance from the beginning when using addTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Fix `remove` error in `carto.viz.Layer`, keeping the reference to the old map ([#124](https://github.com/CartoDB/web-sdk/pull/124/))
 - Fix esm bundle, where typescript interfaces were not correctly ignored by babel ([#126](https://github.com/CartoDB/web-sdk/pull/126/))
 - Fix interactivity styles for common geojson files, expecting cartodb_id to be always present on `carto.viz.source.GeoJSON` ([#125](https://github.com/CartoDB/web-sdk/pull/125/))
+- Fix some `carto.viz.dataview` errors (with remote mode), due to map instance not ready yet ([#136](https://github.com/CartoDB/web-sdk/pull/136/))
+
 
 ## [1.0.0-alpha.2] 2020-07-31
 

--- a/src/viz/layer/Layer.ts
+++ b/src/viz/layer/Layer.ts
@@ -216,15 +216,17 @@ export class Layer extends WithEvents implements StyledLayer {
    * @memberof Layer
    */
   public async addTo(deckInstance: Deck, opts: LayerPosition = {}) {
+    this._deckInstance = deckInstance;
+
     const deckLayer = await this._createDeckLayer();
 
     // collection may have changed during instantiation...
-    const layers = [...deckInstance.props.layers];
+    const layers = [...this._deckInstance.props.layers];
 
     addInTheRightPosition(deckLayer, layers, opts);
 
-    const { onViewStateChange } = deckInstance.props;
-    deckInstance.setProps({
+    const { onViewStateChange } = this._deckInstance.props;
+    this._deckInstance.setProps({
       layers,
       onViewStateChange: args => {
         const { interactionState, viewState } = args;
@@ -241,13 +243,11 @@ export class Layer extends WithEvents implements StyledLayer {
       }
     });
 
-    this._deckInstance = deckInstance;
-
     const { uniqueIdProperty } = this.getSource().getMetadata();
 
-    this._interactivity.setDeckInstance(deckInstance);
+    this._interactivity.setDeckInstance(this._deckInstance);
 
-    this._viewportFeaturesGenerator.setDeckInstance(deckInstance);
+    this._viewportFeaturesGenerator.setDeckInstance(this._deckInstance);
     this._viewportFeaturesGenerator.setDeckLayer(deckLayer);
     this._viewportFeaturesGenerator.setOptions({ uniqueIdProperty });
   }


### PR DESCRIPTION
To avoid some errors with DataViewRemote