### PR TITLE
Remove unneeded mapviews reinstantiations (remote dataviews performance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Fix esm bundle, where typescript interfaces were not correctly ignored by babel ([#126](https://github.com/CartoDB/web-sdk/pull/126/))
 - Fix interactivity styles for common geojson files, expecting cartodb_id to be always present on `carto.viz.source.GeoJSON` ([#125](https://github.com/CartoDB/web-sdk/pull/125/))
 - Fix some `carto.viz.dataview` errors (with remote mode), due to map instance not ready yet ([#136](https://github.com/CartoDB/web-sdk/pull/136/))
+- Fix multiple calls to remote dataviews API (precise mode) every time the map is dragged ([#138](https://github.com/CartoDB/web-sdk/pull/138/))
 
 
 ## [1.0.0-alpha.2] 2020-07-31

--- a/examples/widget/categoryWidget.html
+++ b/examples/widget/categoryWidget.html
@@ -113,7 +113,8 @@
 
         const dataviewViewport = new carto.viz.dataview.Category(countriesLayer, 'continent', {
           operation: 'count',
-          spatialFilter: 'viewport' // data will be updated on every viewport change
+          spatialFilter: 'viewport', // data will be updated on every viewport change
+          mode: 'precise'
         });
 
         /*
@@ -124,7 +125,7 @@
           Widgets include a filtering feature out of the box, so you can display / hide the categories
           on the map
         */
-        new carto.viz.widget.Category('#category-global', dataviewGlobal);
+        // new carto.viz.widget.Category('#category-global', dataviewGlobal);
         new carto.viz.widget.Category('#category-viewport', dataviewViewport);
       }
 

--- a/examples/widget/categoryWidget.html
+++ b/examples/widget/categoryWidget.html
@@ -113,8 +113,7 @@
 
         const dataviewViewport = new carto.viz.dataview.Category(countriesLayer, 'continent', {
           operation: 'count',
-          spatialFilter: 'viewport', // data will be updated on every viewport change
-          mode: 'precise'
+          spatialFilter: 'viewport' // data will be updated on every viewport change
         });
 
         /*
@@ -125,7 +124,7 @@
           Widgets include a filtering feature out of the box, so you can display / hide the categories
           on the map
         */
-        // new carto.viz.widget.Category('#category-global', dataviewGlobal);
+        new carto.viz.widget.Category('#category-global', dataviewGlobal);
         new carto.viz.widget.Category('#category-viewport', dataviewViewport);
       }
 

--- a/src/maps/Client.ts
+++ b/src/maps/Client.ts
@@ -81,18 +81,10 @@ export class Client {
    * @param layergroup
    * @param options
    */
-  public async dataview(
-    layergroup: MapInstance,
-    dataview: string,
-    dataViewOptions?: Partial<MapDataviewsOptions>
-  ) {
+  public async dataview(layergroup: MapInstance, dataViewOptions?: Partial<MapDataviewsOptions>) {
     const {
-      metadata: {
-        dataviews: {
-          [dataview]: { url }
-        }
-      }
-    } = layergroup;
+      0: { url }
+    } = Object.values(layergroup.metadata.dataviews);
 
     const params = {
       api_key: this._credentials.apiKey,

--- a/src/viz/dataview/mode/DataViewRemote.ts
+++ b/src/viz/dataview/mode/DataViewRemote.ts
@@ -74,7 +74,7 @@ export class DataViewRemote extends DataViewMode {
       );
     }
 
-    this.dataOrigin.on(LayerEvent.TILES_LOADED, () => {
+    this.dataOrigin.on(LayerEvent.DATA_CHANGED, () => {
       const deckInstance = (this.dataOrigin as Layer).getMap();
 
       if (deckInstance === undefined) {

--- a/src/viz/layer/Layer.ts
+++ b/src/viz/layer/Layer.ts
@@ -29,7 +29,6 @@ import { basicStyle } from '../style/helpers/basic-style';
 export enum LayerEvent {
   DATA_READY = 'dataReady',
   DATA_CHANGED = 'dataChanged',
-  // TILES_LOADED = 'tilesLoaded',
   FILTER_CHANGE = 'filterChange' // must be the same value as GenericDataSourceEvent.FILTER_CHANGE
 }
 
@@ -87,7 +86,6 @@ export class Layer extends WithEvents implements StyledLayer {
     this.registerAvailableEvents([
       LayerEvent.DATA_READY,
       LayerEvent.DATA_CHANGED,
-      // LayerEvent.TILES_LOADED,
       LayerEvent.FILTER_CHANGE,
       InteractivityEvent.CLICK,
       InteractivityEvent.HOVER
@@ -777,10 +775,6 @@ export class Layer extends WithEvents implements StyledLayer {
       this._emitDataChanged();
       this.dataState = DATA_STATES.READY;
     }
-
-    // if (referer === 'onViewportLoad') {
-    //   this.emit(LayerEvent.TILES_LOADED);
-    // }
   }
 
   /**

--- a/src/viz/layer/Layer.ts
+++ b/src/viz/layer/Layer.ts
@@ -29,7 +29,7 @@ import { basicStyle } from '../style/helpers/basic-style';
 export enum LayerEvent {
   DATA_READY = 'dataReady',
   DATA_CHANGED = 'dataChanged',
-  TILES_LOADED = 'tilesLoaded',
+  // TILES_LOADED = 'tilesLoaded',
   FILTER_CHANGE = 'filterChange' // must be the same value as GenericDataSourceEvent.FILTER_CHANGE
 }
 
@@ -87,7 +87,7 @@ export class Layer extends WithEvents implements StyledLayer {
     this.registerAvailableEvents([
       LayerEvent.DATA_READY,
       LayerEvent.DATA_CHANGED,
-      LayerEvent.TILES_LOADED,
+      // LayerEvent.TILES_LOADED,
       LayerEvent.FILTER_CHANGE,
       InteractivityEvent.CLICK,
       InteractivityEvent.HOVER
@@ -778,9 +778,9 @@ export class Layer extends WithEvents implements StyledLayer {
       this.dataState = DATA_STATES.READY;
     }
 
-    if (referer === 'onViewportLoad') {
-      this.emit(LayerEvent.TILES_LOADED);
-    }
+    // if (referer === 'onViewportLoad') {
+    //   this.emit(LayerEvent.TILES_LOADED);
+    // }
   }
 
   /**
@@ -804,7 +804,7 @@ export class Layer extends WithEvents implements StyledLayer {
     const builtStyle = style instanceof Style ? style : new Style(style);
 
     if (builtStyle.viewport) {
-      this.on(LayerEvent.TILES_LOADED, async () => this.replaceDeckLayer());
+      this.on(LayerEvent.DATA_CHANGED, async () => this.replaceDeckLayer());
     }
 
     return builtStyle;

--- a/src/viz/legend/LegendWidget.ts
+++ b/src/viz/legend/LegendWidget.ts
@@ -34,7 +34,7 @@ export class LegendWidget {
     if (layer.isReady()) {
       layer.getStyle().then(style => {
         if (style.viewport) {
-          layer.on(LayerEvent.TILES_LOADED, () => applyLegendData(legendWidget, layer, options));
+          layer.on(LayerEvent.DATA_CHANGED, () => applyLegendData(legendWidget, layer, options));
         }
       });
       applyLegendData(legendWidget, layer, options);
@@ -42,7 +42,7 @@ export class LegendWidget {
       layer.on(LayerEvent.DATA_READY, () => {
         layer.getStyle().then(style => {
           if (style.viewport) {
-            layer.on(LayerEvent.TILES_LOADED, () => applyLegendData(legendWidget, layer, options));
+            layer.on(LayerEvent.DATA_CHANGED, () => applyLegendData(legendWidget, layer, options));
           }
 
           applyLegendData(legendWidget, layer, options);


### PR DESCRIPTION
- Remove TILES_LOADED event (use DATA_CHANGED instead). I keep this event commented in case we use it in the future.
- I've tried different approaches and with the current code, the easier way is to have a cache in MapsDataviews.ts. Another approach requires a big refactor